### PR TITLE
switch ko to ko_KR translations

### DIFF
--- a/_backend/l10n.php
+++ b/_backend/l10n.php
@@ -22,7 +22,7 @@ class Translator {
         'id_ID' => 'Bahasa Indonesia',
         'it' => 'Italiano',
         'ja' => '日本語',
-        'ko' => '한국어',
+        'ko_KR' => '한국어',
         'lt' => 'Lietuvių kalba',
         'nb' => 'Bokmål',
         'ne' => 'नेपाली',


### PR DESCRIPTION
As per Jung-Kyu Park's request, we should be using the more complete `ko_KR` translations instead of the current `ko` translations.

Not sure if there is anything else we need to do
