### PR TITLE
Fix relative inclusion of logotype.

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@
                     <?php
                         // Embed the SVG to fix scaling in WebKit 1.x,
                         // while preserving CSS options for the image.
-                        include('images/logotype-os.svg');
+                        include __DIR__.'/images/logotype-os.svg';
                     ?>
 
                 </div>


### PR DESCRIPTION
Fixes https://sentry.io/elementary-llc/elementarywebsite/issues/163624878/ :

`ErrorException: include(): Failed opening './images/logotype-os.svg' for inclusion (include_path='.:/usr/share/php')`

This pull request is ready for review.

