### PR TITLE
Fix download tracking by not referencing a global that doesn't exist.

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -92,6 +92,10 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
         $('#amounts').on('click', updateDownloadButton)
         $('#amounts input').on('input', updateDownloadButton)
         $(document).on('ready', updateDownloadButton)
+        
+        // DEBUG
+        if (window.ga) console.log('window.ga is fine')
+        if (ga) console.log('ga is fine')
 
         // ACTION: #download.click: Either initiate a payment or open the download modal.
         $('#download').click(function () {

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -100,12 +100,12 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
             console.log('Starting payment for ' + paymentAmount)
             // Free download
             if (paymentAmount < paymentMinimum) {
-                if (window.ga) ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Skip)', 'Homepage', paymentAmount)
+                if (ga) ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Skip)', 'Homepage', paymentAmount)
                 // Open the Download modal immediately.
                 openDownloadOverlay()
             // Paid download
             } else {
-                if (window.ga) ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Initiated)', 'Homepage', paymentAmount)
+                if (ga) ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Initiated)', 'Homepage', paymentAmount)
                 // Open the Stripe modal first.
                 doStripeCheckout(paymentAmount)
             }
@@ -169,7 +169,7 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
         function doStripePayment (amount, token) {
             var paymentHTTP, $amountTen
             $amountTen = $('#amount-ten')
-            if (window.ga) ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Complete)', 'Homepage', amount)
+            if (ga) ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Complete)', 'Homepage', amount)
             if ($amountTen.val() !== 0) {
                 $('#amounts').html('<input type="hidden" id="amount-ten" value="0">')
                 $amountTen.each(amountSelect)
@@ -188,7 +188,7 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
         }
 
         // ACTION: .download-http.click: Track download over HTTP
-        if (window.ga) {
+        if (ga) {
             $('.download-link').click(function () {
                 ga('send', 'event', config.release.title + ' ' + config.release.version + ' Download (OS)', 'Homepage', detectedOS)
                 ga('send', 'event', config.release.title + ' ' + config.release.version + ' Download (Region)', 'Homepage', config.user.region)


### PR DESCRIPTION
Apparently, back when we had a "war on globals" we forgot to remove all the `window.ga` references. Since all `windows.` references are global, now mostly they fail and we don't track downloads. We still need to have this check in place, despite the promise system, because of the `if (!config.user.trackme)` in [`_scripts/lib/analytics.js`](https://github.com/elementary/website/blob/master/_scripts/lib/analytics.js#L15)

This pull request is ready for review.

