### PR TITLE
ensure loading sentry library when we need it

### DIFF
--- a/_backend/log-echo.php
+++ b/_backend/log-echo.php
@@ -2,6 +2,8 @@
 
 // Setup sentry error logging
 if (isset($config['sentry_key']) && $config['sentry_key'] !== false) {
+    include_once __DIR__.'/lib/autoload.php';
+
     $sentry = new Raven_Client($config['sentry_key']);
     $sentry->install();
 }

--- a/_backend/log-echo.php
+++ b/_backend/log-echo.php
@@ -2,7 +2,7 @@
 
 // Setup sentry error logging
 if (isset($config['sentry_key']) && $config['sentry_key'] !== false) {
-    include_once __DIR__.'/../lib/autoload.php';
+    include_once __DIR__.'/lib/autoload.php';
 
     $sentry = new Raven_Client($config['sentry_key']);
     $sentry->install();

--- a/_backend/log-echo.php
+++ b/_backend/log-echo.php
@@ -2,7 +2,7 @@
 
 // Setup sentry error logging
 if (isset($config['sentry_key']) && $config['sentry_key'] !== false) {
-    include_once __DIR__.'/lib/autoload.php';
+    include_once __DIR__.'/../lib/autoload.php';
 
     $sentry = new Raven_Client($config['sentry_key']);
     $sentry->install();


### PR DESCRIPTION
Fixes issue with chart generator erroring with undefined sentry variable