### PR TITLE
move social links to the top of the page

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -271,7 +271,7 @@ nav a:visited {
     display: inline-block;
     fill: inherit;
     margin: 0;
-    padding: 0 16px;
+    padding: 0 12px;
 }
 
 nav a:focus {

--- a/_templates/footer.php
+++ b/_templates/footer.php
@@ -4,9 +4,6 @@
             <div>
                 <p>
                     Copyright &copy; <?php echo date('Y'); ?> elementary LLC.
-                    <a href="<?php echo $sitewide['root'].'team'; ?>">Team</a>
-                    <a href="<?php echo $sitewide['root'].'brand'; ?>">Brand</a>
-                    <a href="<?php echo $sitewide['root'].'privacy-policy'; ?>">Privacy Policy</a>
                 </p>
                 <div class="popover">
                     <a href="#"><i class="fa fa-language"></i> Language</a>
@@ -33,12 +30,9 @@
                 </div>
             </div>
             <ul>
-                <li><a href="https://www.facebook.com/elementaryos" target="_blank" data-l10n-off title="Facebook"><i class="fa fa-facebook"></i></a></li>
-                <li><a href="https://plus.google.com/+elementary" target="_blank" data-l10n-off title="Google+"><i class="fa fa-google-plus"></i></a></li>
-                <li><a href="https://medium.com/elementaryos" target="_blank" data-l10n-off title="Medium"><i class="fa fa-medium"></i></a></li>
-                <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" data-l10n-off title="Reddit"><i class="fa fa-reddit"></i></a></li>
-                <li><a href="https://elementaryos.stackexchange.com" target="_blank" data-l10n-off title="StackExchange"><i class="fa fa-stack-exchange"></i></i></a></li>
-                <li><a href="https://twitter.com/elementary" target="_blank" data-l10n-off title="Twitter"><i class="fa fa-twitter"></i></a></li>
+                <li><a href="<?php echo $sitewide['root'].'brand'; ?>">Brand</a></li>
+                <li><a href="<?php echo $sitewide['root'].'privacy-policy'; ?>">Privacy Policy</a></li>
+                <li><a href="<?php echo $sitewide['root'].'team'; ?>">Team</a></li>
             </ul>
         </footer>
         <?php

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -132,16 +132,21 @@ $l10n->begin_html_translation();
             <div class="nav-content">
                 <ul>
                     <li><a href="<?php echo $page['lang-root']; ?>" class="logomark"><?php include __DIR__.'/../images/logomark.svg'; ?></a></li>
-                    <li><a href="http://blog.elementary.io">Blog</a></li>
                     <li><a href="<?php echo $page['lang-root'].'support'; ?>">Support</a></li>
+                    <li><a href="https://developer.elementary.io">Developer</a></li>
+                    <li><a href="<?php echo $page['lang-root'].'get-involved'; ?>">Get Involved</a></li>
                     <li><a href="<?php echo $page['lang-root'].'store/'; ?>">Store</a></li>
                     <?php if (isset($_COOKIE['cart']) || substr($page['name'], 0, 5) === 'store') { ?>
                     <li><a href="<?php echo $page['lang-root'].'store/cart'; ?>"><i class="fa fa-shopping-cart"></i></a></li>
                     <?php } ?>
                 </ul>
                 <ul class="right">
-                    <li><a href="https://developer.elementary.io">Developer</a></li>
-                    <li><a href="<?php echo $page['lang-root'].'get-involved'; ?>">Get Involved</a></li>
+                    <li><a href="https://www.facebook.com/elementaryos" target="_blank" data-l10n-off title="Facebook"><i class="fa fa-facebook"></i></a></li>
+                    <li><a href="https://plus.google.com/+elementary" target="_blank" data-l10n-off title="Google+"><i class="fa fa-google-plus"></i></a></li>
+                    <li><a href="https://medium.com/elementaryos" target="_blank" data-l10n-off title="Medium"><i class="fa fa-medium"></i></a></li>
+                    <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" data-l10n-off title="Reddit"><i class="fa fa-reddit"></i></a></li>
+                    <li><a href="https://elementaryos.stackexchange.com" target="_blank" data-l10n-off title="StackExchange"><i class="fa fa-stack-exchange"></i></i></a></li>
+                    <li><a href="https://twitter.com/elementary" target="_blank" data-l10n-off title="Twitter"><i class="fa fa-twitter"></i></a></li>
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
![That's a bold strategy, Cotton](http://thepiton.typepad.com/.a/6a00d8345200e269e2017d43050c47970c-800wi)

This branch:
* puts all the header links that stay on our site on the left side
* puts all the social links on the right side
* Demotes the "blog" link to just be a Medium social network icon
* Moves the links in the footer where the social media links used to be

If the design here is approved, we'll need to do the same for the templates at Developer before merging and then merge those at the same time