### PR TITLE
simplify async loading of analytics

### DIFF
--- a/_scripts/lib/analytics.js
+++ b/_scripts/lib/analytics.js
@@ -21,15 +21,24 @@ export default config.then((config) => {
             })
         }
 
-        Script('https://www.google-analytics.com/analytics.js', () => {
-            console.log('Google analytics loaded')
+        try {
+            Script('https://www.google-analytics.com/analytics.js', () => {
+                console.log('Google analytics loaded')
 
-            window.ga('create', 'UA-19280770-1', 'auto')
-            window.ga('set', 'forceSSL', true)
-            window.ga('set', 'anonymizeIp', true)
-            window.ga('require', 'displayfeatures')
+                window.ga('create', 'UA-19280770-1', 'auto')
+                window.ga('set', 'forceSSL', true)
+                window.ga('set', 'anonymizeIp', true)
+                window.ga('require', 'displayfeatures')
 
-            return resolve(window.ga)
-        })
+                return resolve(window.ga)
+            })
+        } catch (e) {
+            console.log('Unable to load Google analytics. It\'s probably being blocked.')
+
+            return resolve((...args) => {
+                console.log('Google analytics disabled. Logging to console instead')
+                console.log(args)
+            })
+        }
     })
 })

--- a/_scripts/lib/analytics.js
+++ b/_scripts/lib/analytics.js
@@ -21,32 +21,15 @@ export default config.then((config) => {
             })
         }
 
-        try {
-            window['GoogleAnalyticsObject'] = 'ga'
-            window['ga'] = window['ga'] || function (...args) {
-                window['ga'].q = window['ga'].q || []
-                window['ga'].q.push(args)
-            }
-            window['ga'].l = 1 * new Date()
+        Script('https://www.google-analytics.com/analytics.js', () => {
+            console.log('Google analytics loaded')
+
             window.ga('create', 'UA-19280770-1', 'auto')
             window.ga('set', 'forceSSL', true)
             window.ga('set', 'anonymizeIp', true)
             window.ga('require', 'displayfeatures')
-            console.log('Google Analytics preload initialized.')
-        } catch (err) {
-            console.error('Unable to setup Google analytics. Probably getting blocked.')
-            console.error(err)
 
-            return resolve((...args) => {
-                console.log('Google analytics errored during setup. Logging to console instead')
-                console.log(args)
-            })
-        }
-
-        Script('https://www.google-analytics.com/analytics.js', () => {
-            console.log('Google Analytics script loaded.')
+            return resolve(window.ga)
         })
-
-        return resolve(window.ga)
     })
 })


### PR DESCRIPTION
There is no need to put async loading of Google analytics while we are already promising the function. This reduces the confusion and loading problems with analytics by just waiting for it to load before running the code.