### PR TITLE
Don't apply valign to bold in slingshot search results

### DIFF
--- a/_styles/home.css
+++ b/_styles/home.css
@@ -645,7 +645,7 @@ span.results-title {
     background-color: #c4c4c4;
 }
 
-.search-result * {
+.search-result > * {
     display: inline-block;
     vertical-align: middle;
 }


### PR DESCRIPTION
Fixes an issue that becomes much more obvious after switching to Open Sans in slingshot. We only want to apply the vertical align to the direct children of the search result and not their children

This pull request is ready for review.
