### PR TITLE
redo css to make index hero 100vh

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -91,7 +91,7 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
         }
         $('#choice-buttons').on('click', updateDownloadButton)
         $('#choice-buttons input').on('input', updateDownloadButton)
-        $(document).on('ready', updateDownloadButton)
+        updateDownloadButton()
 
         // ACTION: #download.click: Either initiate a payment or open the download modal.
         $('#download').click(function () {

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -76,7 +76,7 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
             var translateDownload = $('#translate-download').text()
             var translatePurchase = $('#translate-purchase').text()
             // Catch case where no buttons are available because the user has already paid.
-            if ($('#amounts').children().length <= 1) {
+            if ($('#choice-buttons').children().length <= 1) {
                 $('#download').text(translateDownload)
             // Catch case where a button is checked or the custom input is above the minimum.
             } else if (
@@ -89,8 +89,8 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
                 $('#download').text(translateDownload)
             }
         }
-        $('#amounts').on('click', updateDownloadButton)
-        $('#amounts input').on('input', updateDownloadButton)
+        $('#choice-buttons').on('click', updateDownloadButton)
+        $('#choice-buttons input').on('input', updateDownloadButton)
         $(document).on('ready', updateDownloadButton)
 
         // ACTION: #download.click: Either initiate a payment or open the download modal.
@@ -171,7 +171,8 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
             $amountTen = $('#amount-ten')
             ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Complete)', 'Homepage', amount)
             if ($amountTen.val() !== 0) {
-                $('#amounts').html('<input type="hidden" id="amount-ten" value="0">')
+                $('#pay-what-you-want').remove()
+                $('#choice-buttons').html('<input type="hidden" id="amount-ten" value="0">')
                 $amountTen.each(amountSelect)
                 updateDownloadButton()
             }

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -14,7 +14,7 @@
 }
 
 #amounts .small-button {
-    margin: 11px 3px;
+    margin: 11px 3px 14px;
 }
 
 .payment-button::before {

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -70,7 +70,6 @@ input:focus + .focus-reveal {
     opacity: 0.65;
 }
 
-
 /***********
 * Sections *
 ***********/

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -9,12 +9,19 @@
 
 #amounts h4 {
     display: inline-block;
-    margin: 11px 3px;
-    padding: 8px 16px;
 }
 
-#amounts .small-button {
-    margin: 11px 3px 14px;
+#choice-buttons {
+    display: inline-flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+@media (min-width: 575px) {
+    #choice-buttons {
+        margin: 0 24px;
+    }
 }
 
 .payment-button::before {
@@ -30,17 +37,16 @@
     font-size: 14px;
     margin-left: 14px;
     margin-right: -21px;
-    margin-top: 19px;
+    margin-top: 0.8em;
     pointer-events: none;
     position: absolute;
 }
 
 #amount-custom {
-    max-width: 170px;
     padding-left: 24px;
     padding-right: 24px;
     text-align: center;
-    width: 100%;
+    width: calc(100% - 6px); /* Work around payent-button::before */
 }
 
 .focus-reveal {

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -7,32 +7,6 @@
 * Responsive Hero *
 ******************/
 
-.page-index .hero {
-    background: url("../images/responsive-images/notebook-small.png") 50% / contain no-repeat;
-    height: 176px;
-    padding-top: 0;
-}
-
-@media all and (min-width: 530px) {
-    .page-index .hero {
-        background-image: url("../images/responsive-images/notebook-medium.png");
-        height: auto;
-        padding-top: 40%;
-    }
-}
-
-@media all and (min-width: 1000px) {
-    .page-index .hero {
-        background-image: url("../images/responsive-images/notebook-large.png");
-    }
-}
-
-@media all and (min-width: 1300px) {
-    .page-index .hero {
-        background-image: url("../images/notebook.png");
-    }
-}
-
 .payment-button::before {
     content: "$";
     float: left;

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -70,6 +70,44 @@ input:focus + .focus-reveal {
     opacity: 0.65;
 }
 
+
+/***********
+* Sections *
+***********/
+
+.section--hero {
+    display: flex;
+    flex-direction: column;
+}
+
+.section--hero .section__detail {
+    flex: 0 0 auto;
+    max-width: 100%;
+    padding: 0 0 16px;
+}
+
+.section--hero .section__showcase {
+    flex: 1 1 auto;
+    margin-bottom: -32px;
+}
+
+.section--hero .section__showcase > img {
+    margin: 0 auto;
+    max-height: 100%;
+    max-width: 100%;
+    object-fit: contain;
+}
+
+@media (min-aspect-ratio: 1/2) and (min-height: 800px) and (max-height: 2000px) {
+    .section--stretched {
+        height: calc(100vh - 56px);
+    }
+
+    .section--stretched > .section__showcase {
+        display: flex;
+    }
+}
+
 /***********************
 * app display sections *
 ***********************/

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -30,7 +30,7 @@
     font-size: 14px;
     margin-left: 14px;
     margin-right: -21px;
-    margin-top: 11px;
+    margin-top: 19px;
     pointer-events: none;
     position: absolute;
 }

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -7,6 +7,16 @@
 * Responsive Hero *
 ******************/
 
+#amounts h4 {
+    display: inline-block;
+    margin: 11px 3px;
+    padding: 8px 16px;
+}
+
+#amounts .small-button {
+    margin: 11px 3px;
+}
+
 .payment-button::before {
     content: "$";
     float: left;

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -435,7 +435,7 @@ footer ul li a:focus {
     object-fit: contain;
 }
 
-@media (min-aspect-ratio: 1/1) and (min-height: 600px) {
+@media (min-aspect-ratio: 1/2) and (min-height: 800px) and (max-height: 2000px) {
     .section--stretched {
         height: calc(100vh - 56px);
     }

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -472,7 +472,7 @@ footer ul li a:focus {
         width: calc(33% - 88px);
     }
 
-    .column + .column {
+    .column + .column + .column {
         margin-left: 16px !important;
     }
 }

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -410,6 +410,41 @@ footer ul li a:focus {
     outline: none;
 }
 
+/***********
+* Sections *
+***********/
+
+.section--hero {
+    display: flex;
+    flex-direction: column;
+}
+
+.section--hero .section__detail {
+    flex: 0 0 auto;
+    max-width: 100%;
+}
+
+.section--hero .section__showcase {
+    flex: 1 1 auto;
+}
+
+.section--hero .section__showcase > img {
+    margin: 0 auto;
+    max-height: 100%;
+    max-width: 100%;
+    object-fit: contain;
+}
+
+@media (min-aspect-ratio: 1/1) and (min-height: 600px) {
+    .section--stretched {
+        height: calc(100vh - 56px);
+    }
+
+    .section--stretched > .section__showcase {
+        display: flex;
+    }
+}
+
 /*********
 * Layout *
 *********/

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -422,6 +422,7 @@ footer ul li a:focus {
 .section--hero .section__detail {
     flex: 0 0 auto;
     max-width: 100%;
+    padding: 0 0 16px;
 }
 
 .section--hero .section__showcase {

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -426,6 +426,7 @@ footer ul li a:focus {
 
 .section--hero .section__showcase {
     flex: 1 1 auto;
+    margin-bottom: -32px;
 }
 
 .section--hero .section__showcase > img {

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -410,43 +410,6 @@ footer ul li a:focus {
     outline: none;
 }
 
-/***********
-* Sections *
-***********/
-
-.section--hero {
-    display: flex;
-    flex-direction: column;
-}
-
-.section--hero .section__detail {
-    flex: 0 0 auto;
-    max-width: 100%;
-    padding: 0 0 16px;
-}
-
-.section--hero .section__showcase {
-    flex: 1 1 auto;
-    margin-bottom: -32px;
-}
-
-.section--hero .section__showcase > img {
-    margin: 0 auto;
-    max-height: 100%;
-    max-width: 100%;
-    object-fit: contain;
-}
-
-@media (min-aspect-ratio: 1/2) and (min-height: 800px) and (max-height: 2000px) {
-    .section--stretched {
-        height: calc(100vh - 56px);
-    }
-
-    .section--stretched > .section__showcase {
-        display: flex;
-    }
-}
-
 /*********
 * Layout *
 *********/

--- a/index.php
+++ b/index.php
@@ -43,7 +43,7 @@
             <div class="section__detail grid">
                 <div class="whole">
                     <div id="amounts">
-                        <h4 id="pay-what-you-want">Pay What You Want</h4>
+                        <h4 id="pay-what-you-want">Pay What You Want:</h4>
                         <?php
                             $paidString = 'has_paid_'.$config['release_title'].'_'.$config['release_version'];
                             $disallowed = [' ', '.'];

--- a/index.php
+++ b/index.php
@@ -54,9 +54,11 @@
                         <?php
                             } else {
                         ?>
-                        <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
-                        <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>
-                        <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount">25</button>
+                        <div class="column">
+                            <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
+                            <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>
+                            <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount">25</button>
+                        </div>
                         <div class="column">
                             <span class="pre-amount">$</span>
                             <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">

--- a/index.php
+++ b/index.php
@@ -49,11 +49,11 @@
                             $disallowed = [' ', '.'];
                             $encoded = urlencode(str_replace($disallowed, '_', $paidString));
                             if ( isset($_COOKIE[$encoded]) && $_COOKIE[$encoded] > 0 ) {
-                                ?>
+                        ?>
                         <input type="hidden" id="amount-ten" value="0">
-                                <?php
+                        <?php
                             } else {
-                                ?>
+                        ?>
                         <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
                         <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>
                         <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount">25</button>
@@ -62,13 +62,15 @@
                             <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
                             <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
                         </div>
-                        <div style="clear:both;"></div>
-                                <?php
+                        <?php
                             }
                         ?>
+                        <div class="column">
+                            <button type="submit" id="download" class="suggested-action">Purchase elementary OS</button>
+                            <p class="small-label"><?php echo $config['release_version'] . ' ' . $config['release_title']; ?> | 1.32 GB (for PC or Mac)</p>
+                        </div>
+                        <div style="clear:both;"></div>
                     </div>
-                    <button type="submit" id="download" class="suggested-action">Purchase elementary OS</button>
-                    <p class="small-label"><?php echo $config['release_version'] . ' ' . $config['release_title']; ?> | 1.32 GB (for PC or Mac)</p>
                 </div>
             </div>
         </section>

--- a/index.php
+++ b/index.php
@@ -365,7 +365,7 @@
                 </div>
             </div>
             <div class="third">
-                <a class="button suggested-action" href="#pay-what-you-want">Pay What You Want</a>
+                <a class="button suggested-action" href="#">Pay What You Want</a>
             </div>
         </section>
         <span id="translate-download" style="display:none;" hidden>Download elementary OS</span>

--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@
             </div>
 
             <div class="section__showcase">
-                <img src="/images/notebook.png" alt="elementary OS desktop"/>
+                <img src="images/notebook.png" alt="elementary OS desktop"/>
             </div>
 
             <div class="section__detail grid">

--- a/index.php
+++ b/index.php
@@ -49,7 +49,9 @@
                             $encoded = urlencode(str_replace($disallowed, '_', $paidString));
                             if ( isset($_COOKIE[$encoded]) && $_COOKIE[$encoded] > 0 ) {
                         ?>
-                        <input type="hidden" id="amount-ten" value="0">
+                        <div id="choice-buttons">
+                            <input type="hidden" id="amount-ten" value="0">
+                        </div>
                         <?php
                             } else {
                         ?>

--- a/index.php
+++ b/index.php
@@ -43,7 +43,6 @@
             <div class="section__detail grid">
                 <div class="whole">
                     <div id="amounts">
-                        <h4 id="pay-what-you-want">Pay What You Want:</h4>
                         <?php
                             $paidString = 'has_paid_'.$config['release_title'].'_'.$config['release_version'];
                             $disallowed = [' ', '.'];
@@ -54,6 +53,7 @@
                         <?php
                             } else {
                         ?>
+                        <h4 id="pay-what-you-want">Pay What You Want:</h4>
                         <div id="choice-buttons">
                             <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
                             <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>

--- a/index.php
+++ b/index.php
@@ -54,15 +54,15 @@
                         <?php
                             } else {
                         ?>
-                        <div class="column">
+                        <div id="choice-buttons">
                             <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
                             <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>
                             <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount">25</button>
-                        </div>
-                        <div class="column">
-                            <span class="pre-amount">$</span>
-                            <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
-                            <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
+                            <div>
+                                <span class="pre-amount">$</span>
+                                <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
+                                <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
+                            </div>
                         </div>
                         <?php
                             }

--- a/index.php
+++ b/index.php
@@ -20,50 +20,56 @@
     require_once __DIR__.'/_backend/classify.current.php';
 ?>
 
-        <section class="grid">
-            <div class="whole">
-                <div id="logotype">
+        <section class="section--hero section--stretched">
+            <div class="section__detail grid">
+                <div class="whole">
+                    <div id="logotype">
 
-                    <?php
-                        // Embed the SVG to fix scaling in WebKit 1.x,
-                        // while preserving CSS options for the image.
-                        include __DIR__.'/images/logotype-os.svg';
-                    ?>
+                        <?php
+                            // Embed the SVG to fix scaling in WebKit 1.x,
+                            // while preserving CSS options for the image.
+                            include __DIR__.'/images/logotype-os.svg';
+                        ?>
 
-                </div>
-                <h4>A fast and open replacement for Windows and macOS</h4>
-            </div>
-        </section>
-        <div class="hero"></div>
-        <section class="grid">
-            <div class="whole">
-                <h4 id="pay-what-you-want">Pay What You Want</h4>
-                <div id="amounts">
-                    <?php
-                        $paidString = 'has_paid_'.$config['release_title'].'_'.$config['release_version'];
-                        $disallowed = [' ', '.'];
-                        $encoded = urlencode(str_replace($disallowed, '_', $paidString));
-                        if ( isset($_COOKIE[$encoded]) && $_COOKIE[$encoded] > 0 ) {
-                            ?>
-                    <input type="hidden" id="amount-ten" value="0">
-                            <?php
-                        } else {
-                            ?>
-                    <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
-                    <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>
-                    <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount">25</button>
-                    <div class="column">
-                        <span class="pre-amount">$</span>
-                        <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
-                        <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
                     </div>
-                    <div style="clear:both;"></div>
-                            <?php
-                        }
-                    ?>
+                    <h4>A fast and open replacement for Windows and macOS</h4>
                 </div>
-                <button type="submit" id="download" class="suggested-action">Purchase elementary OS</button>
-                <p class="small-label"><?php echo $config['release_version'] . ' ' . $config['release_title']; ?> | 1.32 GB (for PC or Mac)</p>
+            </div>
+
+            <div class="section__showcase">
+                <img src="/images/notebook.png" alt="elementary OS desktop"/>
+            </div>
+
+            <div class="section__detail grid">
+                <div class="whole">
+                    <h4 id="pay-what-you-want">Pay What You Want</h4>
+                    <div id="amounts">
+                        <?php
+                            $paidString = 'has_paid_'.$config['release_title'].'_'.$config['release_version'];
+                            $disallowed = [' ', '.'];
+                            $encoded = urlencode(str_replace($disallowed, '_', $paidString));
+                            if ( isset($_COOKIE[$encoded]) && $_COOKIE[$encoded] > 0 ) {
+                                ?>
+                        <input type="hidden" id="amount-ten" value="0">
+                                <?php
+                            } else {
+                                ?>
+                        <button id="amount-five"        value="5"  class="small-button payment-button target-amount">5</button>
+                        <button id="amount-ten"         value="10" class="small-button payment-button target-amount checked">10</button>
+                        <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount">25</button>
+                        <div class="column">
+                            <span class="pre-amount">$</span>
+                            <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
+                            <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
+                        </div>
+                        <div style="clear:both;"></div>
+                                <?php
+                            }
+                        ?>
+                    </div>
+                    <button type="submit" id="download" class="suggested-action">Purchase elementary OS</button>
+                    <p class="small-label"><?php echo $config['release_version'] . ' ' . $config['release_title']; ?> | 1.32 GB (for PC or Mac)</p>
+                </div>
             </div>
         </section>
         <section class="grid">

--- a/index.php
+++ b/index.php
@@ -42,8 +42,8 @@
 
             <div class="section__detail grid">
                 <div class="whole">
-                    <h4 id="pay-what-you-want">Pay What You Want</h4>
                     <div id="amounts">
+                        <h4 id="pay-what-you-want">Pay What You Want</h4>
                         <?php
                             $paidString = 'has_paid_'.$config['release_title'].'_'.$config['release_version'];
                             $disallowed = [' ', '.'];


### PR DESCRIPTION
This changes the CSS for the homepage hero to show the elementary logo, hero image, and payment options all on screen when the page loads. At odd sizes it will revert back to regular flow to avoid a super small hero image. Because we change to use an `img` tag instead of CSS `background-image`, we lost some image responsiveness.

When testing this, the development hero will mess up alignment, so I would recommend running it with 
`PHPENV=production php -S 0.0.0.0:8000 router.php`.