### PR TITLE
Add shipping info to store page

### DIFF
--- a/store/index.php
+++ b/store/index.php
@@ -142,6 +142,14 @@
 
 <?php } ?>
 
+<section class="grid">
+    <div class="two-thirds">
+        <h2>Worldwide Shipping</h2>
+        <p>We now ship all around the world! Place your order and choose from a number of shipping methods to fit your needs. Orders are made on-demand typically within 2–7 days.</p>
+        <p><small>Cuba, Iran, and North Korea excluded. Shipping methods, prices, and times vary by country.</small></p>
+    </div>
+</section>
+
 <script>window.products = <?php echo json_encode(\Store\Product\get_products()) ?></script>
 
 <?php


### PR DESCRIPTION
Fixes #1499

### Changes Summary

- Adds shipping info from Printful (https://www.theprintful.com/shipping and https://www.theprintful.com/faq/shipping-packaging-fulfillment/163-does-printful-ship-to-all-countries-) to the store page

This pull request is ready for review.