### PR TITLE
Move hero image back to CSS

### DIFF
--- a/_styles/home.css
+++ b/_styles/home.css
@@ -86,15 +86,12 @@ input:focus + .focus-reveal {
 }
 
 .section--hero .section__showcase {
+    background-image: url('/images/notebook.png');
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
     flex: 1 1 auto;
     margin-bottom: -32px;
-}
-
-.section--hero .section__showcase > img {
-    margin: 0 auto;
-    max-height: 100%;
-    max-width: 100%;
-    object-fit: contain;
 }
 
 @media (min-aspect-ratio: 1/2) and (min-height: 800px) and (max-height: 2000px) {

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -86,7 +86,7 @@ input:focus + .focus-reveal {
 }
 
 .section--hero .section__showcase {
-    background-image: url('/images/notebook.png');
+    background-image: url('../images/notebook.png');
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;

--- a/index.php
+++ b/index.php
@@ -36,9 +36,7 @@
                 </div>
             </div>
 
-            <div class="section__showcase">
-                <img src="images/notebook.png" alt="elementary OS desktop"/>
-            </div>
+            <div class="section__showcase"></div>
 
             <div class="section__detail grid">
                 <div class="whole">


### PR DESCRIPTION
Fixes hero image being too large in Firefox, IE, Edge.

http://beta.elementary.io/hero-css/

### Changes Summary
- Remove img element
- Add image into CSS

This pull request is not ready for review.
