### PR TITLE
Remove release name from the download button

### DIFF
--- a/index.php
+++ b/index.php
@@ -379,7 +379,8 @@
             <div class="action-area">
                 <a class="button clickable close-modal">Cancel</a>
                 <div class="linked">
-                    <a class="button suggested-action close-modal download-link http" href="<?php echo $download_link.$config['release_filename']; ?>">Download <?php echo $config['release_title']; ?></a>
+                    <a class="button suggested-action close-modal download-link http" href="<?php echo $download_link.
+    ['release_filename']; ?>">Download</a>
                     <a class="button suggested-action close-modal download-link magnet" title="Torrent Magnet Link" href="<?php echo 'magnet:?xt=urn:btih:'.$config['release_magnet'].'&dn='.$config['release_filename']; ?>&tr=https%3A%2F%2Fashrise.com%3A443%2Fphoenix%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.ccc.de%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80%2Fannounce&ws=http:<?php echo $download_link.$config['release_filename']; ?>"><i class="fa fa-magnet"></i></a>
                 </div>
             </div>


### PR DESCRIPTION
As a newcomer, it was extremely confusing to click "Download elementary OS" and then have the next button say "Download Loki". It made me wonder what I'd actually be downloading.

### Change Summary

- [x] Remove the release name from the download button (at that point the user should have enough context to not need a reminder).

This pull request is ready for review.