### PR TITLE
More stripe languages

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -113,7 +113,7 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
 
         // UTILITY: detectStripeLanguage: Detect the language and use the Stripe translation if possible.
         function detectStripeLanguage () {
-            var stripeLanguages = ['de', 'en', 'es', 'fr', 'it', 'jp', 'nl', 'zh']
+            var stripeLanguages = ['da', 'de', 'en', 'es', 'fi', 'fr', 'it', 'ja', 'nl', 'no', 'sv', 'zh']
             var languageCode = $('html').prop('lang')
             // Stripe supports simplified chinese
             if (/^zh_CN/.test(languageCode)) {

--- a/_scripts/pages/store/checkout.js
+++ b/_scripts/pages/store/checkout.js
@@ -78,7 +78,7 @@ Promise.all([jQuery, Stripe, analytics]).then(([$, StripeCheckout, ga]) => {
         var $form = $('form[action$="order"]')
 
         function stripeLanguage () {
-            var stripeLanguages = ['de', 'en', 'es', 'fr', 'it', 'jp', 'nl', 'zh']
+            var stripeLanguages = ['da', 'de', 'en', 'es', 'fi', 'fr', 'it', 'ja', 'nl', 'no', 'sv', 'zh']
             var languageCode = $('html').prop('lang')
 
             // Stripe supports simplified chinese


### PR DESCRIPTION
Now Stripe Checkout translated into [twelve languages](https://stripe.com/docs/checkout#supported-languages), but not all of them are presented on the website.

### Changes Summary

- [x] Add Danish, Finnish, Norwegian and Swedish language codes
- [x] Fix Japanese language code from `jp` to `ja`

This pull request is ready for review.
