### PR TITLE
Change Other to Unknown

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -161,7 +161,7 @@ Promise.all([config, analytics, jQuery, Stripe, modal]).then(([config, ga, $, St
             if (ua.indexOf('Linux') >= 0) {
                 return 'Linux'
             }
-            return 'Other'
+            return 'Unknown'
         }
         var detectedOS = detectOS()
 


### PR DESCRIPTION
As shown here, GA groups minor reported elements as other, so we should never report like that.

![image](https://cloud.githubusercontent.com/assets/831389/21740089/4f3d9518-d4ae-11e6-9053-0217201ae49c.png)

This pull request is ready for review.
