### PR TITLE
Add new classes for developer index page

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -1231,8 +1231,6 @@ i.fa.fa-close.close-modal {
     }
 }
 
-
-
 /*************************
 * Teaser group with icon *
 *************************/

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -547,7 +547,7 @@ footer ul li a:focus {
         width: calc(66% - 48px);
     }
 
-    .grid *:only-child p {
+    .grid *:only-child > p {
         text-align: center;
     }
 }
@@ -1228,5 +1228,30 @@ i.fa.fa-close.close-modal {
     footer,
     .dont-print {
         display: none;
+    }
+}
+
+
+
+/*************************
+* Teaser group with icon *
+*************************/
+
+@media only screen and (min-width: 640px) {
+    .flex-row {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .flex-column {
+        flex: 1 1 auto;
+    }
+
+    .no-shrink {
+        flex-shrink: 0;
+    }
+
+    .gutter-right {
+        margin-right: 16px;
     }
 }

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -547,7 +547,7 @@ footer ul li a:focus {
         width: calc(66% - 48px);
     }
 
-    .grid *:only-child > p {
+    .grid *:only-child p {
         text-align: center;
     }
 }
@@ -1253,5 +1253,9 @@ i.fa.fa-close.close-modal {
 
     .gutter-right {
         margin-right: 16px;
+    }
+
+    .flex-row .flex-column p {
+        text-align: left;
     }
 }


### PR DESCRIPTION
Fixes #1526 

### Changes Summary
- New flexbox-based styles to align icons on the left side (only for for screen widths > 640px).
- On smaller screens, the four teaser blocks retain their centered layout with icons above the text.

There is a complimentary pull request on the elementary/houston repository to apply the necessary markup changes: https://github.com/elementary/houston/pull/368

I don’t have access to Edge or Safari for testing, so please keep that in mind while reviewing this PR.
