### PR TITLE
fix select update resetting state input

### DIFF
--- a/_scripts/pages/store/cart.js
+++ b/_scripts/pages/store/cart.js
@@ -129,7 +129,7 @@ Promise.all([jQuery, analytics]).then(([$, ga]) => {
         }
 
         // Hide the inputs we don't need depending on the country
-        $('form[action$="checkout"]').on('change', () => updateAddressForm(true))
+        $('form[action$="checkout"] select[name="country"]').on('change', () => updateAddressForm(true))
         updateAddressForm(false)
     })
 })


### PR DESCRIPTION
Fixes #1565 

### Changes Summary

- Don't reset the state input on _every_ form change
