### PR TITLE
Add AppCenter promotion, swap apps and AppCenter on home page

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -44,6 +44,13 @@
             <p class="text-center">With your help, we've been able to grow from a small group of passionate volunteers into a tiny company. Every little bit of help is one step closer to hiring another full-time developer.</p>
         </div>
     </div>
+    <div class="grid">
+        <div class="two-thirds">
+            <h2>Indiegogo</h2>
+            <p class="text-center">We’re currently crowdfunding AppCenter, the pay-what-you-want app store, on Indiegogo. By backing us there, you'll be helping us pay for our remote team to get together in person with developers from our community for a week long sprint in Denver, Colorado.</p>
+            <a class="button flat" href="https://igg.me/at/appcenter" target="_blank">Back AppCenter</a>
+        </div>
+    </div>
     <section class="grid">
         <div class="third">
             <img alt="Patreon" src="images/get-involved/patreon.svg">

--- a/index.php
+++ b/index.php
@@ -91,8 +91,21 @@
                 <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Lightweight and fast… Completely community-based, and has a real flair for design and appearances.&rdquo; —@lifehacker http://elementary.io" data-tweet-suffix=" — @lifehacker http://elementary.io" target="_blank">&ldquo;Lightweight and fast… Completely community-based, and has a real flair for design and appearances.&rdquo;</a>
             </div>
         </section>
+        <section id="appcenter" class="grey">
+            <div class="app-display app-display--overflow">
+                <img class="app-display__image" src="images/screenshots/appcenter.png" srcset="images/screenshots/appcenter@2x.png 2x" alt="elementary appcenter categories"/>
+                <div class="app-display__description">
+                    <img src="images/icons/apps/128/system-software-install.svg" />
+                    <h2>The Indie, Open Source App Store</h2>
+                    <p>AppCenter delivers native, Open Source apps to elementary OS. Quickly discover new apps and easily update the ones you already have. And soon, support indie developers directly through pay-what-you-want purchases.</p>
+                    <a href="developer" class="read-more">Become a Developer</a>
+                    <br>
+                    <a href="https://igg.me/at/appcenter" class="read-more">Back AppCenter on Indiegogo</a>
+                </div>
+            </div>
+        </section>
         <section>
-            <div id="showcase" class="row grey">
+            <div id="showcase" class="row">
                 <div class="pantheon" style="display:none;">
                     <div id="notification-container">
                         <div class="window" type="notification">
@@ -269,17 +282,6 @@
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </section>
-        <section id="appcenter">
-            <div class="app-display app-display--overflow">
-                <img class="app-display__image" src="images/screenshots/appcenter.png" srcset="images/screenshots/appcenter@2x.png 2x" alt="elementary appcenter categories"/>
-                <div class="app-display__description">
-                    <img src="images/icons/apps/128/system-software-install.svg" />
-                    <h2>The Indie, Open Source App Store</h2>
-                    <p>AppCenter brings handcrafted apps and extensions directly to your desktop. Quickly discover new apps and easily update the ones you already have. No license keys, no subscriptions, no trial periods.</p>
-                    <a href="developer" class="read-more">Become a Developer</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Fixes #1570 

### Changes Summary

- Swap AppCenter and Apps sections on homepage
- Update AppCenter homepage copy
- Add link to AppCenter homepage section
- Add section to Get Involved -> Funding

Didn't include a navbar link because I was not sure if you wanted it on the right in icon form, or the left in text form.

This pull request [ is ] ready for review.
