### PR TITLE
add noopener to new tab links

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -143,12 +143,12 @@ $l10n->begin_html_translation();
                     <?php } ?>
                 </ul>
                 <ul class="right">
-                    <li><a href="https://www.facebook.com/elementaryos" target="_blank" data-l10n-off title="Facebook"><i class="fa fa-facebook"></i></a></li>
-                    <li><a href="https://plus.google.com/+elementary" target="_blank" data-l10n-off title="Google+"><i class="fa fa-google-plus"></i></a></li>
-                    <li><a href="https://medium.com/elementaryos" target="_blank" data-l10n-off title="Medium"><i class="fa fa-medium"></i></a></li>
-                    <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" data-l10n-off title="Reddit"><i class="fa fa-reddit"></i></a></li>
-                    <li><a href="https://elementaryos.stackexchange.com" target="_blank" data-l10n-off title="StackExchange"><i class="fa fa-stack-exchange"></i></a></li>
-                    <li><a href="https://twitter.com/elementary" target="_blank" data-l10n-off title="Twitter"><i class="fa fa-twitter"></i></a></li>
+                    <li><a href="https://www.facebook.com/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Facebook"><i class="fa fa-facebook"></i></a></li>
+                    <li><a href="https://plus.google.com/+elementary" target="_blank" rel="noopener" data-l10n-off title="Google+"><i class="fa fa-google-plus"></i></a></li>
+                    <li><a href="https://medium.com/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Medium"><i class="fa fa-medium"></i></a></li>
+                    <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Reddit"><i class="fa fa-reddit"></i></a></li>
+                    <li><a href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener" data-l10n-off title="StackExchange"><i class="fa fa-stack-exchange"></i></a></li>
+                    <li><a href="https://twitter.com/elementary" target="_blank" rel="noopener" data-l10n-off title="Twitter"><i class="fa fa-twitter"></i></a></li>
                 </ul>
             </div>
         </nav>

--- a/_templates/legacy.php
+++ b/_templates/legacy.php
@@ -21,7 +21,7 @@ if (getenv('PHPENV') === 'production' && $is_HTTP) {
         <div id="legacy-warning-buttons">
             <a href="#" onClick="document.getElementById('legacy-warning').style.display = 'none';">Dismiss</a>
             <a href="https://<?php echo $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ?>">Load HTTPS</a>
-            <a class="suggested-action" href="http://browsehappy.com/" target="_blank">Upgrade</a>
+            <a class="suggested-action" href="http://browsehappy.com/" target="_blank" rel="noopener">Upgrade</a>
         </div>
     </div>
 
@@ -32,7 +32,7 @@ if (getenv('PHPENV') === 'production' && $is_HTTP) {
         <p>This version of Internet Explorer is out of date and may contain bugs or security vulnerabilities. Please <a href="http://browsehappy.com/">upgrade</a> to edge or an alternative web browser.</p>
         <div id="legacy-warning-buttons">
             <a href="#" onClick="document.getElementById('legacy-warning').style.display = 'none';">Dismiss</a>
-            <a class="suggested-action" href="http://browsehappy.com/" target="_blank">Learn More</a>
+            <a class="suggested-action" href="http://browsehappy.com/" target="_blank" rel="noopener">Learn More</a>
         </div>
     </div>
 

--- a/code-of-conduct.php
+++ b/code-of-conduct.php
@@ -27,7 +27,7 @@
                 <h2>Consequences</h2>
                 <p>If you choose not to follow this code of conduct or otherwise disrupt the community, we reserve the right to do the following: alter or remove any content you&rsquo;ve posted; deactivate your account on the website; kick you out of an IRC channel; ban you from the site, IRC channels, or related services; or otherwise prevent you from interacting with the community.</p>
                 <hr>
-                <p><em>The elementary Code of Conduct is licensed under the <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution-Share Alike 3.0</a> license. Certain aspects have been inspired by the <a href="http://www.ubuntu.com/about/about-ubuntu/conduct" target="_blank">Ubuntu Code of Conduct</a>.</em></p>
+                <p><em>The elementary Code of Conduct is licensed under the <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">Creative Commons Attribution-Share Alike 3.0</a> license. Certain aspects have been inspired by the <a href="http://www.ubuntu.com/about/about-ubuntu/conduct" target="_blank" rel="noopener">Ubuntu Code of Conduct</a>.</em></p>
             </div>
 <?php
     include $template['footer'];

--- a/get-involved.php
+++ b/get-involved.php
@@ -48,14 +48,14 @@
         <div class="two-thirds">
             <h2>Indiegogo</h2>
             <p class="text-center">We’re currently crowdfunding AppCenter, the pay-what-you-want app store, on Indiegogo. By backing us there, you'll be helping us pay for our remote team to get together in person with developers from our community for a week long sprint in Denver, Colorado.</p>
-            <a class="button flat" href="https://igg.me/at/appcenter" target="_blank">Back AppCenter</a>
+            <a class="button flat" href="https://igg.me/at/appcenter" target="_blank" rel="noopener">Back AppCenter</a>
         </div>
     </div>
     <section class="grid">
         <div class="third">
             <img alt="Patreon" src="images/get-involved/patreon.svg">
-            <p>Patreon works like an ongoing crowdfunding campaign. Choose an amount, get rewards, and help us reach our goals. <a class="read-more" href="https://www.patreon.com/" target="blank">Learn More</a></p>
-            <a class="button flat" href="https://www.patreon.com/elementary" target="_blank">Become a Patron</a>
+            <p>Patreon works like an ongoing crowdfunding campaign. Choose an amount, get rewards, and help us reach our goals. <a class="read-more" href="https://www.patreon.com/" target="_blank" rel="noopener">Learn More</a></p>
+            <a class="button flat" href="https://www.patreon.com/elementary" target="_blank" rel="noopener">Become a Patron</a>
         </div>
         <div class="third">
             <i class="fa fa-paypal"></i>
@@ -70,13 +70,13 @@
         <div class="third">
             <i class="fa fa-shopping-cart"></i>
             <p>Help us financially, plus get some exclusive elementary gear to show your support to friends, family, and coworkers.</p>
-            <a class="button flat" href="<?php echo $page['lang-root'].'store/'; ?>" target="_blank">Visit Store</a>
+            <a class="button flat" href="<?php echo $page['lang-root'].'store/'; ?>" target="_blank" rel="noopener">Visit Store</a>
         </div>
     </section>
     <div class="grid">
         <div class="two-thirds">
             <img alt="Bountysource" src="images/open-source/bountysource.svg">
-            <p>BountySource puts funds directly in the hands of developers by rewarding them for committing fixes or creating new features. Set a bounty on the issues that matter to you most or fund a specific app. You can also set up a recurring subscription. <a class="read-more" href="https://github.com/bountysource/frontend/wiki/Frequently-Asked-Questions" target="blank">Learn More</a></p>
+            <p>BountySource puts funds directly in the hands of developers by rewarding them for committing fixes or creating new features. Set a bounty on the issues that matter to you most or fund a specific app. You can also set up a recurring subscription. <a class="read-more" href="https://github.com/bountysource/frontend/wiki/Frequently-Asked-Questions" target="_blank" rel="noopener">Learn More</a></p>
 
             <div class="actions">
                 <a class="button flat" href="https://bugs.launchpad.net/elementary/+bugs?orderby=-importance&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.tag=bounty&field.omit_dupes=on&field.has_branches=on&field.has_no_branches=on&field.has_blueprints=on&field.has_no_blueprints=on&search=Search">Bountied Bugs</a>
@@ -97,8 +97,8 @@
             <p>Our website is also openly translated using an online platform called Transifex. <a href="/docs/translation-guide#translating-our-website" class="read-more">Learn More</a></p>
 
             <div class="actions">
-                <a class="button flat suggested-action" href="https://translations.launchpad.net/elementary" target="_blank">Translate elementary OS</a>
-                <a class="button flat" href="https://www.transifex.com/projects/p/elementary-mvp/" target="_blank">Translate This Website</a>
+                <a class="button flat suggested-action" href="https://translations.launchpad.net/elementary" target="_blank" rel="noopener">Translate elementary OS</a>
+                <a class="button flat" href="https://www.transifex.com/projects/p/elementary-mvp/" target="_blank" rel="noopener">Translate This Website</a>
             </div>
         </div>
         <div class="half">
@@ -127,8 +127,8 @@
             <p>elementary provides basic documentation for both users and developers. All of our documentation is written in Markdown and hosted on GitHub, so submitting a change or a new section is a piece of cake.</p>
 
             <div class="actions actions--column">
-                <a class="button flat suggested-action" href="https://github.com/elementary/website/blob/master/docs/learning-the-basics.md" target="_blank">Learning The Basics Guide</a>
-                <a class="button flat" href="https://github.com/elementary/website/blob/master/docs/code/getting-started.md" target="_blank">Developer Docs</a>
+                <a class="button flat suggested-action" href="https://github.com/elementary/website/blob/master/docs/learning-the-basics.md" target="_blank" rel="noopener">Learning The Basics Guide</a>
+                <a class="button flat" href="https://github.com/elementary/website/blob/master/docs/code/getting-started.md" target="_blank" rel="noopener">Developer Docs</a>
             </div>
         </div>
     </div>
@@ -144,8 +144,8 @@
         <h2>Web Development</h2>
         <p>Our website is built using HTML, CSS, PHP, and JavaScript. We're always looking for people experienced in those areas who would like to contribute and make it even better.</p>
         <div class="actions">
-            <a class="button flat suggested-action" href="https://github.com/elementary/website" target="_blank">Fork Our Website on GitHub</a>
-            <a class="button flat" href="https://github.com/elementary/website/issues" target="_blank">Report a Website Issue</a>
+            <a class="button flat suggested-action" href="https://github.com/elementary/website" target="_blank" rel="noopener">Fork Our Website on GitHub</a>
+            <a class="button flat" href="https://github.com/elementary/website/issues" target="_blank" rel="noopener">Report a Website Issue</a>
         </div>
     </div>
 </section>
@@ -200,9 +200,9 @@
         ?>
         <div class="whole">
             <div class="actions">
-                <a class="button flat suggested-action" href="https://code.launchpad.net/~elementary-pantheon" target="_blank">Browse Our Desktop Code</a>
-                <a class="button flat" href="https://code.launchpad.net/~elementary-apps" target="_blank">Browse Our Apps' Code</a>
-                <a class="button flat" href="https://bugs.launchpad.net/elementary/+bugs?orderby=-importance&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.tag=bitesize&field.omit_dupes=on&field.has_branches=on&field.has_no_branches=on&field.has_blueprints=on&field.has_no_blueprints=on&search=Search" target="_blank">Bitesized Bugs</a>
+                <a class="button flat suggested-action" href="https://code.launchpad.net/~elementary-pantheon" target="_blank" rel="noopener">Browse Our Desktop Code</a>
+                <a class="button flat" href="https://code.launchpad.net/~elementary-apps" target="_blank" rel="noopener">Browse Our Apps' Code</a>
+                <a class="button flat" href="https://bugs.launchpad.net/elementary/+bugs?orderby=-importance&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.tag=bitesize&field.omit_dupes=on&field.has_branches=on&field.has_no_branches=on&field.has_blueprints=on&field.has_no_blueprints=on&search=Search" target="_blank" rel="noopener">Bitesized Bugs</a>
                 <a class="button flat" href="https://bugs.launchpad.net/elementary/+bugs?orderby=-importance&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.tag=bounty&field.omit_dupes=on&field.has_branches=on&field.has_no_branches=on&field.has_blueprints=on&field.has_no_blueprints=on&search=Search">Bountied Bugs</a>
             </div>
         </div>
@@ -220,7 +220,7 @@
             <p>We're always open to new ideas for elementary OS's visual design. Get started by sharing mockups with <a href="https://plus.google.com/communities/104613975513761463450/stream/856346d7-1c23-4912-9549-bcfc76b32937" class="read-more">our Google+ Community</a></p>
 
             <div class="actions actions--column">
-                <a class="button flat suggested-action" href="/docs/human-interface-guidelines" target="_blank">Read the Interface Guidelines</a>
+                <a class="button flat suggested-action" href="/docs/human-interface-guidelines" target="_blank" rel="noopener">Read the Interface Guidelines</a>
                 <a class="button flat" href="https://github.com/elementary/mockups">See Our Mockups</a>
             </div>
         </div>
@@ -229,8 +229,8 @@
             <p>We use a system on Launchpad called Blueprints to create detailed explanations of new features and changes to the user interface.</p>
 
             <div class="actions actions--column">
-                <a class="button flat suggested-action" href="/docs/code/reference#proposing-design-changes" target="_blank">Read About Our Workflow</a>
-                <a class="button flat" href="https://blueprints.launchpad.net/elementary" target="_blank">Browse Our Blueprints</a>
+                <a class="button flat suggested-action" href="/docs/code/reference#proposing-design-changes" target="_blank" rel="noopener">Read About Our Workflow</a>
+                <a class="button flat" href="https://blueprints.launchpad.net/elementary" target="_blank" rel="noopener">Browse Our Blueprints</a>
             </div>
         </div>
     </div>

--- a/index.php
+++ b/index.php
@@ -69,16 +69,16 @@
         <section class="grid" id="the-press">
             <h4>What the press is saying about elementary OS:</h4>
             <div class="third">
-                <a href="http://www.wired.com/2013/11/elementaryos/" target="_blank"><?php include __DIR__.'/images/thirdparty-logos/wired.svg'; ?></a>
-                <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;elementary OS is different… a beautiful and powerful operating system that will run well even on old PCs&rdquo; — @WIRED http://elementary.io" data-tweet-suffix=" — @WIRED http://elementary.io" target="_blank">&ldquo;elementary OS is different… a beautiful and powerful operating system that will run well even on old PCs&rdquo;</a>
+                <a href="http://www.wired.com/2013/11/elementaryos/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/wired.svg'; ?></a>
+                <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;elementary OS is different… a beautiful and powerful operating system that will run well even on old PCs&rdquo; — @WIRED http://elementary.io" data-tweet-suffix=" — @WIRED http://elementary.io" target="_blank" rel="noopener">&ldquo;elementary OS is different… a beautiful and powerful operating system that will run well even on old PCs&rdquo;</a>
             </div>
             <div class="third">
-                <a href="https://web.archive.org/web/20150312112222/http://www.maclife.com/article/columns/future_os_x_may_be_more_elementary_ios_7" target="_blank"><?php include __DIR__.'/images/thirdparty-logos/maclife.svg'; ?></a>
-                <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;a fast, low-maintenance platform that can be installed virtually anywhere&rdquo; —@MacLife http://elementary.io" data-tweet-suffix=" — @MacLife http://elementary.io" target="_blank">&ldquo;a fast, low-maintenance platform that can be installed virtually anywhere&rdquo;</a>
+                <a href="https://web.archive.org/web/20150312112222/http://www.maclife.com/article/columns/future_os_x_may_be_more_elementary_ios_7" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/maclife.svg'; ?></a>
+                <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;a fast, low-maintenance platform that can be installed virtually anywhere&rdquo; —@MacLife http://elementary.io" data-tweet-suffix=" — @MacLife http://elementary.io" target="_blank" rel="noopener">&ldquo;a fast, low-maintenance platform that can be installed virtually anywhere&rdquo;</a>
             </div>
             <div class="third">
-                <a href="http://lifehacker.com/how-to-move-on-after-windows-xp-without-giving-up-your-1556573928" target="_blank"><?php include __DIR__.'/images/thirdparty-logos/lifehacker.svg'; ?></a>
-                <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Lightweight and fast… Completely community-based, and has a real flair for design and appearances.&rdquo; —@lifehacker http://elementary.io" data-tweet-suffix=" — @lifehacker http://elementary.io" target="_blank">&ldquo;Lightweight and fast… Completely community-based, and has a real flair for design and appearances.&rdquo;</a>
+                <a href="http://lifehacker.com/how-to-move-on-after-windows-xp-without-giving-up-your-1556573928" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/lifehacker.svg'; ?></a>
+                <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Lightweight and fast… Completely community-based, and has a real flair for design and appearances.&rdquo; —@lifehacker http://elementary.io" data-tweet-suffix=" — @lifehacker http://elementary.io" target="_blank" rel="noopener">&ldquo;Lightweight and fast… Completely community-based, and has a real flair for design and appearances.&rdquo;</a>
             </div>
         </section>
         <section id="appcenter" class="grey">
@@ -365,7 +365,7 @@
             <img alt="Download elementary OS icon" src="images/icons/apps/48/ubiquity.svg">
             <div class="content-area">
                 <p class="primary">Choose a Download</p>
-                <p>Download from a localized server or by magnet link. For help and more info, see the <a class="read-more" href="docs/installation" target="_blank">installation guide</a></p>
+                <p>Download from a localized server or by magnet link. For help and more info, see the <a class="read-more" href="docs/installation" target="_blank" rel="noopener">installation guide</a></p>
             </div>
             <div class="action-area">
                 <a class="button clickable close-modal">Cancel</a>

--- a/open-source.php
+++ b/open-source.php
@@ -33,15 +33,15 @@
             <p class="oss-title">elementary OS Applications</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://launchpad.net/maya" target="_blank"><span>Calendar</span></a>
-            <a class="button sub-item" href="https://launchpad.net/snap-elementary" target="_blank"><span>Camera</span></a>
-            <a class="button sub-item" href="https://launchpad.net/pantheon-files" target="_blank"><span>Files</span></a>
-            <a class="button sub-item" href="https://launchpad.net/pantheon-mail" target="_blank"><span>Mail</span></a>
-            <a class="button sub-item" href="https://launchpad.net/noise" target="_blank"><span>Music</span></a>
-            <a class="button sub-item" href="https://launchpad.net/pantheon-photos" target="_blank"><span>Photos</span></a>
-            <a class="button sub-item" href="https://launchpad.net/scratch" target="_blank"><span>Scratch</span></a>
-            <a class="button sub-item" href="https://launchpad.net/pantheon-terminal" target="_blank"><span>Terminal</span></a>
-            <a class="button sub-item" href="https://launchpad.net/audience" target="_blank"><span>Videos</span></a>
+            <a class="button sub-item" href="https://launchpad.net/maya" target="_blank" rel="noopener"><span>Calendar</span></a>
+            <a class="button sub-item" href="https://launchpad.net/snap-elementary" target="_blank" rel="noopener"><span>Camera</span></a>
+            <a class="button sub-item" href="https://launchpad.net/pantheon-files" target="_blank" rel="noopener"><span>Files</span></a>
+            <a class="button sub-item" href="https://launchpad.net/pantheon-mail" target="_blank" rel="noopener"><span>Mail</span></a>
+            <a class="button sub-item" href="https://launchpad.net/noise" target="_blank" rel="noopener"><span>Music</span></a>
+            <a class="button sub-item" href="https://launchpad.net/pantheon-photos" target="_blank" rel="noopener"><span>Photos</span></a>
+            <a class="button sub-item" href="https://launchpad.net/scratch" target="_blank" rel="noopener"><span>Scratch</span></a>
+            <a class="button sub-item" href="https://launchpad.net/pantheon-terminal" target="_blank" rel="noopener"><span>Terminal</span></a>
+            <a class="button sub-item" href="https://launchpad.net/audience" target="_blank" rel="noopener"><span>Videos</span></a>
         </div>
     </div>
     <div class="platform-item half">
@@ -50,13 +50,13 @@
             <p class="oss-title">Pantheon Desktop Shell</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://github.com/elementary/stylesheet" target="_blank"><span>GTK+ Stylesheet</span></a>
-            <a class="button sub-item" href="https://github.com/elementary/icons" target="_blank"><span>Icon Theme</span></a>
-            <a class="button sub-item" href="https://launchpad.net/gala" target="_blank"><span>Gala</span></a>
-            <a class="button sub-item" href="https://launchpad.net/plank" target="_blank"><span>Plank</span></a>
-            <a class="button sub-item" href="https://launchpad.net/slingshot" target="_blank"><span>Slingshot</span></a>
-            <a class="button sub-item" href="https://launchpad.net/switchboard" target="_blank"><span>Switchboard</span></a>
-            <a class="button sub-item" href="https://launchpad.net/wingpanel" target="_blank"><span>Wingpanel</span></a>
+            <a class="button sub-item" href="https://github.com/elementary/stylesheet" target="_blank" rel="noopener"><span>GTK+ Stylesheet</span></a>
+            <a class="button sub-item" href="https://github.com/elementary/icons" target="_blank" rel="noopener"><span>Icon Theme</span></a>
+            <a class="button sub-item" href="https://launchpad.net/gala" target="_blank" rel="noopener"><span>Gala</span></a>
+            <a class="button sub-item" href="https://launchpad.net/plank" target="_blank" rel="noopener"><span>Plank</span></a>
+            <a class="button sub-item" href="https://launchpad.net/slingshot" target="_blank" rel="noopener"><span>Slingshot</span></a>
+            <a class="button sub-item" href="https://launchpad.net/switchboard" target="_blank" rel="noopener"><span>Switchboard</span></a>
+            <a class="button sub-item" href="https://launchpad.net/wingpanel" target="_blank" rel="noopener"><span>Wingpanel</span></a>
         </div>
     </div>
     <div class="platform-item half">
@@ -65,100 +65,100 @@
             <p class="oss-title">Pantheon Platform</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://launchpad.net/contractor" target="_blank"><span>Contractor</span></a>
-            <a class="button sub-item" href="https://launchpad.net/granite" target="_blank"><span>Granite</span></a>
-            <a class="button sub-item" href="https://launchpad.net/capnet-assist" target="_blank"><span>Captive Portal Assistant</span></a>
-            <a class="button sub-item" href="https://launchpad.net/pantheon-online-accounts" target="_blank"><span>Pantheon Online Accounts</span></a>
-            <a class="button sub-item" href="https://launchpad.net/pantheon-agent-polkit" target="_blank"><span>Polkit Agent</span></a>
+            <a class="button sub-item" href="https://launchpad.net/contractor" target="_blank" rel="noopener"><span>Contractor</span></a>
+            <a class="button sub-item" href="https://launchpad.net/granite" target="_blank" rel="noopener"><span>Granite</span></a>
+            <a class="button sub-item" href="https://launchpad.net/capnet-assist" target="_blank" rel="noopener"><span>Captive Portal Assistant</span></a>
+            <a class="button sub-item" href="https://launchpad.net/pantheon-online-accounts" target="_blank" rel="noopener"><span>Pantheon Online Accounts</span></a>
+            <a class="button sub-item" href="https://launchpad.net/pantheon-agent-polkit" target="_blank" rel="noopener"><span>Polkit Agent</span></a>
         </div>
     </div>
     <hr class="dotted full">
     <div class="platform-item third" id="ubuntu">
-        <a href="https://ubuntu.com/" target="_blank">
+        <a href="https://ubuntu.com/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/ubuntu.svg" alt="Ubuntu">
             <h3 class="oss-title">Ubuntu</h3>
             <p class="oss-subtitle">Desktop Libraries &amp; Repositories</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://launchpad.net/ayatana" target="_blank"><span>Ayatana</span></a>
-            <a class="button sub-item" href="https://launchpad.net/bamf" target="_blank"><span>BAMF</span></a>
-            <a class="button sub-item" href="https://launchpad.net/libunity" target="_blank"><span>libunity</span></a>
-            <a class="button sub-item" href="https://launchpad.net/ubiquity" target="_blank"><span>Ubiquity</span></a>
+            <a class="button sub-item" href="https://launchpad.net/ayatana" target="_blank" rel="noopener"><span>Ayatana</span></a>
+            <a class="button sub-item" href="https://launchpad.net/bamf" target="_blank" rel="noopener"><span>BAMF</span></a>
+            <a class="button sub-item" href="https://launchpad.net/libunity" target="_blank" rel="noopener"><span>libunity</span></a>
+            <a class="button sub-item" href="https://launchpad.net/ubiquity" target="_blank" rel="noopener"><span>Ubiquity</span></a>
         </div>
     </div>
     <div class="platform-item third" id="gtk">
-        <a href="http://gtk.org/" target="_blank">
+        <a href="http://gtk.org/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/gtk.svg" alt="GTK+">
             <h3 class="oss-title">GTK+</h3>
             <p class="oss-subtitle">User Interface Toolkit</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://wiki.gnome.org/Accessibility" target="_blank"><span>ATK</span></a>
-            <a class="button sub-item" href="http://www.gtk.org/" target="_blank"><span>GTK+</span></a>
-            <a class="button sub-item" href="http://www.pango.org/" target="_blank"><span>Pango</span></a>
-            <a class="button sub-item" href="https://cairographics.org/" target="_blank"><span>Cairo</span></a>
+            <a class="button sub-item" href="https://wiki.gnome.org/Accessibility" target="_blank" rel="noopener"><span>ATK</span></a>
+            <a class="button sub-item" href="http://www.gtk.org/" target="_blank" rel="noopener"><span>GTK+</span></a>
+            <a class="button sub-item" href="http://www.pango.org/" target="_blank" rel="noopener"><span>Pango</span></a>
+            <a class="button sub-item" href="https://cairographics.org/" target="_blank" rel="noopener"><span>Cairo</span></a>
         </div>
     </div>
     <div class="platform-item third" id="gnome">
-        <a href="https://gnome.org/" target="_blank">
+        <a href="https://gnome.org/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/gnome.svg" alt="GNOME">
             <h3 class="oss-title">GNOME</h3>
             <p class="oss-subtitle">Desktop Libraries</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://wiki.gnome.org/Projects/dconf" target="_blank"><span>D-Conf</span></a>
-            <a class="button sub-item" href="https://wiki.gnome.org/Projects/GLib" target="_blank"><span>GLib</span></a>
-            <a class="button sub-item" href="https://wiki.gnome.org/Projects/PolicyKit" target="_blank"><span>PolicyKit</span></a>
-            <a class="button sub-item" href="https://wiki.gnome.org/Projects/Vala" target="_blank"><span>Vala</span></a>
+            <a class="button sub-item" href="https://wiki.gnome.org/Projects/dconf" target="_blank" rel="noopener"><span>D-Conf</span></a>
+            <a class="button sub-item" href="https://wiki.gnome.org/Projects/GLib" target="_blank" rel="noopener"><span>GLib</span></a>
+            <a class="button sub-item" href="https://wiki.gnome.org/Projects/PolicyKit" target="_blank" rel="noopener"><span>PolicyKit</span></a>
+            <a class="button sub-item" href="https://wiki.gnome.org/Projects/Vala" target="_blank" rel="noopener"><span>Vala</span></a>
         </div>
     </div>
     <div class="platform-item two-thirds" id="fdo">
-        <a href="https://freedesktop.org/" target="_blank">
+        <a href="https://freedesktop.org/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/freedesktop.svg" alt="FreeDesktop">
             <h3 class="oss-title">FreeDesktop.org</h3>
             <p class="oss-subtitle">Base Technology</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/dbus/" target="_blank"><span>D-Bus</span></a>
-            <a class="button sub-item" href="https://gstreamer.freedesktop.org/" target="_blank"><span>GStreamer</span></a>
-            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/libinput/" target="_blank"><span>libinput</span></a>
-            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/LightDM/" target="_blank"><span>LightDM</span></a>
-            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/PulseAudio/" target="_blank"><span>PulseAudio</span></a>
-            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/systemd/" target="_blank"><span>systemd</span></a>
+            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/dbus/" target="_blank" rel="noopener"><span>D-Bus</span></a>
+            <a class="button sub-item" href="https://gstreamer.freedesktop.org/" target="_blank" rel="noopener"><span>GStreamer</span></a>
+            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/libinput/" target="_blank" rel="noopener"><span>libinput</span></a>
+            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/LightDM/" target="_blank" rel="noopener"><span>LightDM</span></a>
+            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/PulseAudio/" target="_blank" rel="noopener"><span>PulseAudio</span></a>
+            <a class="button sub-item" href="https://www.freedesktop.org/wiki/Software/systemd/" target="_blank" rel="noopener"><span>systemd</span></a>
         </div>
     </div>
     <div class="platform-item third" id="xorg">
-        <a href="http://x.org/" target="_blank">
+        <a href="http://x.org/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/xorg.svg" alt="X.org">
             <h3 class="oss-title">X.org</h3>
             <p class="oss-subtitle">Display Server &amp; Windowing System</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://www.x.org/" target="_blank"><span>X11</span></a>
-            <a class="button sub-item" href="https://www.x.org/wiki/XServer/" target="_blank"><span>XServer</span></a>
+            <a class="button sub-item" href="https://www.x.org/" target="_blank" rel="noopener"><span>X11</span></a>
+            <a class="button sub-item" href="https://www.x.org/wiki/XServer/" target="_blank" rel="noopener"><span>XServer</span></a>
         </div>
     </div>
     <div class="platform-item half" id="gnu">
-        <a href="http://gnu.org/" target="_blank">
+        <a href="http://gnu.org/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/gnu.svg" alt="GNU">
             <h3 class="oss-title">GNU</h3>
             <p class="oss-subtitle">Compiler &amp; Core Utilities</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://www.gnu.org/software/bash/" target="_blank"><span>Bash</span></a>
-            <a class="button sub-item" href="https://www.gnu.org/software/gcc/" target="_blank"><span>GCC</span></a>
-            <a class="button sub-item" href="https://www.gnu.org/software/libc/" target="_blank"><span>GNU C Library</span></a>
-            <a class="button sub-item" href="https://www.gnu.org/software/coreutils/" target="_blank"><span>Coreutils</span></a>
+            <a class="button sub-item" href="https://www.gnu.org/software/bash/" target="_blank" rel="noopener"><span>Bash</span></a>
+            <a class="button sub-item" href="https://www.gnu.org/software/gcc/" target="_blank" rel="noopener"><span>GCC</span></a>
+            <a class="button sub-item" href="https://www.gnu.org/software/libc/" target="_blank" rel="noopener"><span>GNU C Library</span></a>
+            <a class="button sub-item" href="https://www.gnu.org/software/coreutils/" target="_blank" rel="noopener"><span>Coreutils</span></a>
         </div>
     </div>
     <div class="platform-item half" id="linux">
-        <a href="https://kernel.org/" target="_blank">
+        <a href="https://kernel.org/" target="_blank" rel="noopener">
             <img class="oss-logo" src="images/open-source/linux.svg" alt="Linux">
             <h3 class="oss-title">Linux</h3>
             <p class="oss-subtitle">Filesystem, Hardware, Networking &amp; Drivers</p>
         </a>
         <div>
-            <a class="button sub-item" href="https://kernel.org/" target="_blank"><span>Kernel</span></a>
+            <a class="button sub-item" href="https://kernel.org/" target="_blank" rel="noopener"><span>Kernel</span></a>
         </div>
     </div>
 </div>

--- a/privacy-policy.php
+++ b/privacy-policy.php
@@ -14,38 +14,38 @@
                 <p class="text-center"><strong>You can choose to disable or selectively turn off any cookies or third-party cookies in your browser settings.</strong></p>
                 <p>This site uses cookies for incremental improvements. You may find the services function without them but at a reduced usability. For example, the site will not remember if you have previously paid for elementary OS; by default you will be asked to pay again.</p>
                 <h5 data-l10n-off>CloudFlare</h5>
-                <p>Stores cookies to log behavioral elements and analyze potential threats. For more information, see the <a class="read-more" target="_blank" href="https://www.cloudflare.com/security-policy">CloudFlare Privacy &amp; Security Policy</a></p>
+                <p>Stores cookies to log behavioral elements and analyze potential threats. For more information, see the <a class="read-more" target="_blank" rel="noopener" href="https://www.cloudflare.com/security-policy">CloudFlare Privacy &amp; Security Policy</a></p>
                 <h5 data-l10n-off>Google Analytics</h5>
-                <p>Stores cookies to collect information—including the number of visitors to this site, from where they were referred, and the pages they visit—in an anonymous form. This information is used to help improve the site. For more information, see Google's article on <a class="read-more" target="_blank" href="https://support.google.com/analytics/answer/6004245">Safeguarding Your Data</a></p>
+                <p>Stores cookies to collect information—including the number of visitors to this site, from where they were referred, and the pages they visit—in an anonymous form. This information is used to help improve the site. For more information, see Google's article on <a class="read-more" target="_blank" rel="noopener" href="https://support.google.com/analytics/answer/6004245">Safeguarding Your Data</a></p>
                 <h5 data-l10n-off>Stripe</h5>
-                <p>Uses cookies to remember your last order and your country so it knows what card types to offer for payments. For more information, see <a class="read-more" target="_blank" href="https://stripe.com/privacy">Stripe's Privacy Policy</a></p>
+                <p>Uses cookies to remember your last order and your country so it knows what card types to offer for payments. For more information, see <a class="read-more" target="_blank" rel="noopener" href="https://stripe.com/privacy">Stripe's Privacy Policy</a></p>
                 <h5>Manage Cookies</h5>
                 <p>As you have already visited our site, you may wish to manage cookies already set in your browser. Links to the relevant instructions can be found below.</p>
-                <a target="_blank" href="https://support.google.com/chrome/answer/95647" class="column">
+                <a target="_blank" rel="noopener" href="https://support.google.com/chrome/answer/95647" class="column">
                     <img src="images/privacy-policy/chrome_128x128.png" data-l10n-off alt="Google Chrome" class="browsers-list" />
                     <h4 data-l10n-off>Chrome</h4>
                 </a>
-                <a target="_blank" href="https://support.mozilla.org/en-US/kb/delete-cookies-remove-info-websites-stored" class="column">
+                <a target="_blank" rel="noopener" href="https://support.mozilla.org/en-US/kb/delete-cookies-remove-info-websites-stored" class="column">
                     <img src="images/privacy-policy/firefox_128x128.png" data-l10n-off alt="Firefox" class="browsers-list" />
                     <h4 data-l10n-off>Firefox</h4>
                 </a>
-                <a target="_blank" href="http://windows.microsoft.com/en-gb/internet-explorer/delete-manage-cookies" class="column">
+                <a target="_blank" rel="noopener" href="http://windows.microsoft.com/en-gb/internet-explorer/delete-manage-cookies" class="column">
                     <img src="images/privacy-policy/internet-explorer_128x128.png" data-l10n-off alt="Internet Explorer" class="browsers-list" />
                     <h4 data-l10n-off>IE</h4>
                 </a>
-                <a target="_blank" href="https://www.opera.com/blogs/news/2015/08/how-to-manage-cookies-in-opera/" class="column">
+                <a target="_blank" rel="noopener" href="https://www.opera.com/blogs/news/2015/08/how-to-manage-cookies-in-opera/" class="column">
                     <img src="images/privacy-policy/opera_128x128.png" data-l10n-off alt="Opera" class="browsers-list" />
                     <h4 data-l10n-off>Opera</h4>
                 </a>
-                <a target="_blank" href="http://support.apple.com/kb/PH17191" class="column">
+                <a target="_blank" rel="noopener" href="http://support.apple.com/kb/PH17191" class="column">
                     <img src="images/privacy-policy/safari_128x128.png" data-l10n-off alt="Safari" class="browsers-list" />
                     <h4 data-l10n-off>Safari</h4>
                 </a>
-                <a target="_blank" href="http://midori-browser.org/faqs/#blacklist_cookies" class="column">
+                <a target="_blank" rel="noopener" href="http://midori-browser.org/faqs/#blacklist_cookies" class="column">
                     <img src="images/privacy-policy/midori_256x256.png" data-l10n-off alt="Midori" class="browsers-list" />
                     <h4 data-l10n-off>Midori</h4>
                 </a>
-                <a target="_blank" href="https://help.gnome.org/users/epiphany/stable/data-cookies.html" class="column">
+                <a target="_blank" rel="noopener" href="https://help.gnome.org/users/epiphany/stable/data-cookies.html" class="column">
                     <img src="images/icons/apps/48/internet-web-browser.svg" data-l10n-off alt="Epiphany" class="browsers-list" />
                     <h4 data-l10n-off>Epiphany</h4>
                 </a>

--- a/support.php
+++ b/support.php
@@ -20,52 +20,52 @@
 </div>
 
 <div class="row apps">
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/maya" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/maya" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/office-calendar.svg" alt="Calendar"/>
         <span>Calendar</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/snap" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/snap" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/accessories-camera.svg" alt="Camera"/>
         <span>Camera</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/pantheon-files" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/pantheon-files" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/system-file-manager.svg" alt="Files"/>
         <span>Files</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/geary" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/geary" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/internet-mail.svg" alt="Geary"/>
         <span data-l10n-off>Mail</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/epiphany" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/epiphany" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/web-browser.svg" alt="Epiphany"/>
         <span data-l10n-off>Epiphany</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/noise" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/noise" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/multimedia-audio-player.svg" alt="Music"/>
         <span>Music</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/photos" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/photos" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/multimedia-photo-manager.svg" alt="Photos"/>
         <span>Photos</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/scratch" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/scratch" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/accessories-text-editor.svg" alt="Text Editor"/>
         <span data-l10n-off>Scratch</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/settings" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/settings" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/preferences-desktop.svg" alt="System Settings"/>
         <span>System Settings</span>
     </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/videos" target="_blank">
+    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/videos" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/multimedia-video-player.svg" alt="Videos"/>
         <span>Videos</span>
     </a>
@@ -84,7 +84,7 @@
         <p>Walk through the desktop, multi-tasking, keyboard shortcuts and more.</p>
     </a>
 
-    <a class="column third" href="https://elementaryos.stackexchange.com" target="_blank">
+    <a class="column third" href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener">
         <i class="fa fa-stack-exchange"></i>
         <h3 class="read-more">StackExchange</h3>
         <p>Check out answers to some of the most common questions we get.</p>


### PR DESCRIPTION
TIL about https://developers.google.com/web/tools/lighthouse/audits/noopener

### Changes
- Adds `rel="noopener"` to all links with `target="_blank"`
