### PR TITLE
Add more support for old browsers in critical JS functions

### DIFF
--- a/_scripts/page.js
+++ b/_scripts/page.js
@@ -47,12 +47,25 @@ export function branch () {
  * url
  * Returns full base url of the website
  *
- * @return {String} - full url base path for website
+ * @return {String} - full url base path for website _WITHOUT_ trailing slash
  */
 export function url () {
-    if (window.location.host === 'beta.elementary.io' && branch() != null) {
-        return `${window.location.origin}/${branch()}`
+    let basePath = window.location.origin
+
+    // For the old browsers that probably shouldn't be on the web anymore
+    if (basePath == null) {
+        basePath = `${window.location.protocol}//${window.location.hostname}`
+        if (window.location.port) basePath = `${basePath}:${window.location.port}`
     }
 
-    return window.location.origin
+    // Trim all of the crap at the end of the url
+    basePath = basePath.split('#')[0]
+    if (basePath[basePath.length - 1] === '/') basePath = basePath.substring(0, basePath.length - 1)
+
+    // Ensure we fix this _one_ edge case
+    if (basePath === 'https://beta.elementary.io' && branch() != null) {
+        return `${basePath}/${branch()}`
+    }
+
+    return basePath
 }

--- a/_scripts/polyfill.js
+++ b/_scripts/polyfill.js
@@ -1,0 +1,9 @@
+/**
+ * _scripts/polyfill.js
+ * Overwrites global values for all browsers to support things like Promises
+ * I'm sorry world :'(
+ */
+
+var _Promise = require('core-js/library/es6/promise')
+
+global.Promise = _Promise

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -147,3 +147,17 @@ gulp.task('styles', () => {
  * @returns {Task} - a gulp task for building
  */
 gulp.task('default', gulp.parallel('images', 'styles'))
+
+/**
+ * watch
+ * Watches for asset changes and builds what it needs to
+ *
+ * @returns {Task} - a gulp task for building
+ */
+gulp.task('watch', gulp.series('default', function watch () {
+    gulp.watch('_images/**/*.png', gulp.series('png'))
+    gulp.watch('_images/**/*.jpg', gulp.series('jpg'))
+    gulp.watch('_images/**/*.svg', gulp.series('svg'))
+
+    gulp.watch('_styles/**/*.css', gulp.series('styles'))
+}))

--- a/package.json
+++ b/package.json
@@ -8,13 +8,11 @@
     "babel-loader": "^6.2.10",
     "babel-preset-env": "^1.1.8",
     "core-js": "^2.4.1",
-    "exports-loader": "^0.6.3",
     "glob": "^7.1.1",
     "gulp": "gulpjs/gulp#4.0",
     "gulp-imagemin": "^3.1.1",
     "gulp-postcss": "^6.3.0",
     "gulp-svgo": "^1.0.3",
-    "imports-loader": "^0.7.0",
     "postcss-cssnext": "^2.9.0",
     "scriptjs": "^2.5.8",
     "webpack": "^2.2.1"

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -46,7 +46,8 @@ glob.sync(scriptPattern).forEach((p) => {
     const name = p
     .replace(path.resolve(__dirname, '_scripts', 'pages') + path.sep, '')
     .replace('.js', '')
-    scriptFiles[name] = p
+
+    scriptFiles[name] = [path.resolve(__dirname, '_scripts', 'polyfill.js'), p]
 })
 
 export default {
@@ -77,12 +78,9 @@ export default {
         }
     },
     plugins: [
-        new webpack.ProvidePlugin({
-            'Promise': 'imports-loader?this=>global!exports-loader?global.Promise!core-js/library/es6/promise'
-        }),
         new webpack.optimize.CommonsChunkPlugin({
             name: 'common',
-            minChunks: Infinity
+            minChunks: 2
         }),
         new webpack.optimize.UglifyJsPlugin({
             minimize: true,


### PR DESCRIPTION
Fixes old browsers being old (kinda)

### Changes Summary

- Fixes issue with `window.location.origin` being undefined in old browsers
- Update polyfill loading as this is simpler and works better
- Adds a `gulp watch` task because I'm lazy
- Fixes issue with webpack common chunks so they actual work now

This pull request is ready for review.
