### PR TITLE
Start tracking payment failures

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -23,6 +23,7 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
         // ACTION: amountSelect: Track the current and previous amounts selected.
         var amountSelect = function (e) {
             var targetID = $(e.target).attr('id') // avoids null values vs native js
+            console.log('Setting payment target to #' + targetID)
             if (currentButton !== targetID) previousButton = currentButton
             currentButton = targetID
 

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -152,7 +152,7 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
             if ($amountTen.val() !== 0) {
                 $('#pay-what-you-want').remove()
                 $('#choice-buttons').html('<input type="hidden" id="amount-ten" value="0">')
-                $amountTen.each(amountSelect)
+                currentButton = 'amount-ten'
                 updateDownloadButton()
             }
 

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -7,8 +7,9 @@ import analytics from '~/lib/analytics'
 import jQuery from '~/lib/jquery'
 import modal from '~/lib/modal'
 
-import Payment from '~/widgets/payment'
+import { url } from '~/page'
 import config from '~/config'
+import Payment from '~/widgets/payment'
 
 Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, Payment]) => {
     const payment = new Payment(`${config.release.title} ${config.release.version}`)
@@ -145,25 +146,26 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
 
         // ACTION: doStripePayment: Actually process the payment via Stripe
         function doStripePayment (amount, token) {
-            var paymentHTTP, $amountTen
-            $amountTen = $('#amount-ten')
+            var $amountTen = $('#amount-ten')
             if ($amountTen.val() !== 0) {
                 $('#pay-what-you-want').remove()
                 $('#choice-buttons').html('<input type="hidden" id="amount-ten" value="0">')
                 $amountTen.each(amountSelect)
                 updateDownloadButton()
             }
-            paymentHTTP = new XMLHttpRequest()
-            paymentHTTP.open('POST', './api/payment.php', true)
-            paymentHTTP.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
-            paymentHTTP.send(
-                'description=' + encodeURIComponent(config.release.title + ' ' + config.release.version) +
-                '&amount=' + amount +
-                '&token=' + token.id +
-                '&email=' + encodeURIComponent(token.email) +
-                '&os=' + detectedOS
-            )
-            ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Complete)', 'Homepage', amount)
+
+            // Because jQuery "promises" are not A+ standard
+            return new Promise((resolve, reject) => {
+                $.post(`${url()}/api/payment`, {
+                    description: `${config.release.title} ${config.release.version}`,
+                    amount: amount,
+                    token: token.id,
+                    email: token.email,
+                    os: detectedOS
+                })
+                .done((res) => resolve(res))
+                .fail((xhr, status) => reject(new Error(status)))
+            })
         }
 
         // ACTION: .download-http.click: Track download over HTTP

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -111,10 +111,11 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
                 payment.checkout(paymentAmount, 'USD')
                 .then(([token]) => doStripePayment(paymentAmount, token))
                 .then(() => openDownloadOverlay())
+                .then(() => ga('send', 'event', `${config.release.title} ${config.release.version} Payment (Complete)`, 'Homepage', paymentAmount))
                 .catch((err) => {
                     console.error('Error while making payment')
                     console.error(err)
-                    ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Failed)', 'Homepage', paymentAmount)
+                    ga('send', 'event', `${config.release.title} ${config.release.version} Payment (Failed)`, 'Homepage', paymentAmount)
                     openDownloadOverlay() // Just in case. Don't interupt the flow
                     throw err // rethrow so it can be picked up by error tracking
                 })

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -113,7 +113,7 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
                 .catch((err) => {
                     console.error('Error while making payment')
                     console.error(err)
-
+                    ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Failed)', 'Homepage', paymentAmount)
                     openDownloadOverlay() // Just in case. Don't interupt the flow
                     throw err // rethrow so it can be picked up by error tracking
                 })
@@ -147,7 +147,6 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
         function doStripePayment (amount, token) {
             var paymentHTTP, $amountTen
             $amountTen = $('#amount-ten')
-            ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Complete)', 'Homepage', amount)
             if ($amountTen.val() !== 0) {
                 $('#pay-what-you-want').remove()
                 $('#choice-buttons').html('<input type="hidden" id="amount-ten" value="0">')
@@ -164,6 +163,7 @@ Promise.all([config, analytics, jQuery, Payment, modal]).then(([config, ga, $, P
                 '&email=' + encodeURIComponent(token.email) +
                 '&os=' + detectedOS
             )
+            ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Complete)', 'Homepage', amount)
         }
 
         // ACTION: .download-http.click: Track download over HTTP

--- a/api/payment.php
+++ b/api/payment.php
@@ -37,6 +37,8 @@ if (isset($_POST['token'])) {
         // Don't use log_echo because we don't want finance stuff echoing.
         error_log($e);
         $sentry->captureMessage($e);
+
+        http_response_code(500);
         echo 'An error occurred.';
         die();
     }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -55,7 +55,7 @@ export default {
     entry: scriptFiles,
     output: {
         filename: '[name].js',
-        path: './scripts',
+        path: path.resolve(__dirname, 'scripts'),
         publicPath: '/scripts',
         sourceMapFilename: '[name].map.js'
     },


### PR DESCRIPTION
Partially fixes #1612

### Changes Summary

- Start tracking payment failures.
- Move success tracking to end, so an error being thrown stops the event from ever being sent.

This pull request is ready for review.
