### PR TITLE
return floatval() for os_payment_getcookie

### DIFF
--- a/_backend/os-payment.php
+++ b/_backend/os-payment.php
@@ -48,7 +48,7 @@ function os_payment_getcookie (string $version) {
         $string = os_payment_encode('has_paid_' . $config['release_title'] . '_' . $config['release_version']);
 
         if (isset($_COOKIE[$string])) {
-            return intval($_COOKIE[$string]);
+            return floatval($_COOKIE[$string]);
         }
     }
 


### PR DESCRIPTION
Fixes #
Else, even if the user specifies money in the range of 0.01 to 0.99, the button won't say "Purchase elementary OS", and if user decided to pay $0.99, payment window won't trigger.

### Changes Summary
- change return type floatval() for os_payment_getcookie from int to float

This pull request [ is ] ready for review.
