### PR TITLE
make empty strings return original text when translating page

### DIFF
--- a/_backend/l10n.php
+++ b/_backend/l10n.php
@@ -165,7 +165,8 @@ class Translator {
         }
 
         if (isset($this->translations[$domain][$id]) &&
-            is_string($this->translations[$domain][$id])) {
+            is_string($this->translations[$domain][$id]) &&
+            ($this->translations[$domain][$id] !== "")) {
             return $this->translations[$domain][$id];
         } else {
             return $string;


### PR DESCRIPTION
When a translation line contains an empty string, we will no longer translate it. This is the first step to fixing weblate showing 100% translations for everything.
