### PR TITLE
Disable related videos on YouTube embeds

### DIFF
--- a/docs/human-interface-guidelines.md
+++ b/docs/human-interface-guidelines.md
@@ -18,7 +18,7 @@ For sections that have not yet been written, please refer to [The GNOME HIG](htt
 
 The elementary OS HIG isn't just about a set of concrete rules; it's meant to be flexible and extensible. As such, this very first portion of the guideline is all about the guiding philosophy we employ. For a quick crash course, we like "The User is Drunk":
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/r2CbbBLVaPk" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/r2CbbBLVaPk?rel=0" frameborder="0" allowfullscreen></iframe>
 
 ## What Design Is Not {#what-design-is-not}
 
@@ -58,7 +58,7 @@ If possible, completely avoid presenting any settings or configuration in your a
 
 Design with sane defaults in mind. elementary OS apps put strong emphasis on the out of the box experience. If your app has to be configured before a user is comfortable using it, they may not take the time to configure it at all and simply use another app instead.
 
-<iframe width="420" height="315" src="https://www.youtube.com/embed/G2YNqr-V-xM" frameborder="0" allowfullscreen></iframe>
+<iframe width="420" height="315" src="https://www.youtube.com/embed/G2YNqr-V-xM?rel=0" frameborder="0" allowfullscreen></iframe>
 
 ### Ask the Operating System {#ask-the-operating-system}
 


### PR DESCRIPTION
Fixes #1659

### Changes Summary

- Disables related videos on YouTube embeds
- Added `?rel=0` to embed's URL

This pull request is ready for review.
