### PR TITLE
add cache to gulp image processing

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -4,6 +4,8 @@
  */
 
 import gulp from 'gulp'
+import cache from 'gulp-cached'
+import changed from 'gulp-changed'
 
 import imagemin from 'gulp-imagemin'
 import svgo from 'gulp-svgo'
@@ -28,6 +30,8 @@ gulp.task('png', () => {
     const dest = 'images'
 
     return gulp.src(src, { base })
+    .pipe(changed(dest))
+    .pipe(cache('png'))
     .pipe(imagemin())
     .pipe(gulp.dest(dest))
 })
@@ -44,6 +48,8 @@ gulp.task('jpg', () => {
     const dest = 'images'
 
     return gulp.src(src, { base })
+    .pipe(changed(dest))
+    .pipe(cache('jpg'))
     .pipe(imagemin())
     .pipe(gulp.dest(dest))
 })
@@ -110,6 +116,8 @@ gulp.task('svg', () => {
     const dest = 'images'
 
     return gulp.src(src, { base })
+    .pipe(changed(dest))
+    .pipe(cache('svg'))
     .pipe(svgo())
     .pipe(gulp.dest(dest))
 })
@@ -134,6 +142,7 @@ gulp.task('styles', () => {
     const dest = 'styles'
 
     return gulp.src(src, { base })
+    .pipe(changed(dest))
     .pipe(postcss([
         cssnext({ browsers })
     ]))

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "core-js": "^2.4.1",
     "glob": "^7.1.1",
     "gulp": "gulpjs/gulp#4.0",
+    "gulp-cached": "^1.1.1",
+    "gulp-changed": "^3.0.0",
     "gulp-imagemin": "^3.1.1",
     "gulp-postcss": "^6.3.0",
     "gulp-svgo": "^1.0.3",


### PR DESCRIPTION
Adds cache to gulp processing. This won't help much for building new branches on our server, but it will help a lot with master.
