### PR TITLE
Update gulpfile.babel.js

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,6 +19,21 @@ const browsers = [
 ]
 
 /**
+ * store
+ * Copies store files to production folder
+ *
+ * @returns {Task} - a gulp task for store designs
+ */
+gulp.task('store', () => {
+    const base = '_images'
+    const src = ['_images/_images/store/designs/**/*']
+    const dest = 'images/store/designs'
+
+    return gulp.src(src, { base })
+    .pipe(gulp.dest(dest))
+})
+
+/**
  * png
  * Optimizes png images
  *
@@ -128,7 +143,7 @@ gulp.task('svg', () => {
  *
  * @returns {Task} - a gulp task for all image optimizations
  */
-gulp.task('images', gulp.parallel('png', 'jpg', 'svg'))
+gulp.task('images', gulp.parallel('store', 'png', 'jpg', 'svg'))
 
 /**
  * styles

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -25,7 +25,7 @@ const browsers = [
  * @returns {Task} - a gulp task for store designs
  */
 gulp.task('store', () => {
-    const base = '_images'
+    const base = '_images/store/designs'
     const src = ['_images/store/designs/**/*']
     const dest = 'images/store/designs'
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -26,7 +26,7 @@ const browsers = [
  */
 gulp.task('store', () => {
     const base = '_images'
-    const src = ['_images/_images/store/designs/**/*']
+    const src = ['_images/store/designs/**/*']
     const dest = 'images/store/designs'
 
     return gulp.src(src, { base })


### PR DESCRIPTION
Copy store design assets when building

Fixes #issues

### Changes Summary

- Gulp task to copy over the psd files when building the site
