### PR TITLE
add bin files in case you dont have it installed locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "jpegtran-bin": "^3.2.0",
+    "optipng-bin": "^4.0.0",
     "stylelint": "^7.10.1"
   },
   "scripts": {


### PR DESCRIPTION
For some reason no server had this problem except the production server. Not even travis.
Fixes builds on the server

## Changes
- Adds bin files for `jpg` and `png` transformations incase they are not installed locally