### PR TITLE
Fix #1737 -Update flex value.

### DIFF
--- a/_styles/home.css
+++ b/_styles/home.css
@@ -169,7 +169,7 @@ input:focus + .focus-reveal {
     }
 
     .app-display--overflow .app-display__image {
-        flex: 0 0 auto;
+        flex: 0 auto auto;
         order: 2;
         overflow: visible;
     }


### PR DESCRIPTION
Due to flex: 0 0 auto; the website wasn't responsive enough and the image at "image/screenshots/appcenter.jpg" overflows for resolution greater than 1020 x A .

Fixes #1737 

### Changes Summary

- flex: 0 0 auto; has been updated to flex: 0 auto auto;

This pull request is ready for review.
