### PR TITLE
More coherent licenses in Getting Started doc

### DIFF
--- a/docs/code/getting-started.md
+++ b/docs/code/getting-started.md
@@ -273,7 +273,7 @@ Every app also comes with an .appdata.xml file. This file contains all the infor
         <!-- Copyright 2017 Your Name <you@email.com> -->
         <component type="desktop">
           <id>com.github.yourusername.yourrepositoryname.desktop</id>
-          <metadata_license>CC0</metadata_license>
+          <metadata_license>GPL</metadata_license>
           <name>Your App's Name</name>
           <summary>A Catchy Tagline</summary>
           <description>


### PR DESCRIPTION
The [Copying](https://elementary.io/docs/code/getting-started#copyright) paragraph in the Getting Started guide talks about the `GPL` and instructs the developer to create a `COPYING` file with the `GPL`:

```
For elementary apps this is typically the GNU General Public License (GPL).
```

The newer [AppData.xml](https://elementary.io/docs/code/getting-started#appdata) paragraph shows how to specify a license in this file but uses the `CC0` license as an example:

```xml
<metadata_license>CC0</metadata_license>
```

Wouldn't it make more sense to use the same license in both places?

I feel we should not send people down the `CC0` versus `GPL` rabbit hole when they are simply trying to create their first Vala app.

This pull request is ready for review.
