### PR TITLE
fix team page strings not found unless api key

### DIFF
--- a/team.php
+++ b/team.php
@@ -124,6 +124,10 @@
             ?>
 
         </div>
+
+        <?php
+            }
+        ?>
     </div>
 </section>
 <section class="grid">
@@ -132,6 +136,11 @@
         <p>elementary would not exist without the involvement of dedicated community members and collaborators from other free and open source projects.</p>
     </div>
     <div class="whole">
+
+        <?php
+            if ($apiResponse['ok']) {
+        ?>
+
         <div class="team-directory">
 
             <?php


### PR DESCRIPTION
Fixes #1760

### Changes Summary

- Display all text even if api response is not ok from slack on 'team.php` page
