### PR TITLE
Linux section's kernel button hover state now matches others

### DIFF
--- a/_styles/open-source.css
+++ b/_styles/open-source.css
@@ -108,6 +108,7 @@ hr.dotted {
 
 #linux .sub-item {
     background-color: #f9c440;
+    color: inherit;
 }
 
 #linux .sub-item:focus {


### PR DESCRIPTION
Fixes #1827 

### Changes Summary

- Added `color: inherit` to linux section's existing sub-item selector. 

All the colored buttons found in the other vendor/library sections already had no perceivable hover state due to a more specific selector setting their text color. Linux section was left out presumably for contrast and legibility reasons, but as a result was not included in that override of text color on hover. 
Setting its color to inherit within an adjacent, existing, comparably specific rule takes care of the problem.

This pull request is ready for review