### PR TITLE
Cite the docs for AUTHORS

### DIFF
--- a/docs/code/getting-started.md
+++ b/docs/code/getting-started.md
@@ -309,6 +309,8 @@ The AUTHORS file is pretty straightforward. This file contains your name and ema
 
 <!--/email_off-->
 
+For more information about the AUTHORS file and its importance, see the [GNU maintainer documentation](https://www.gnu.org/prep/maintain/html_node/Recording-Contributors.html).
+
 ### Copying {#copyright}
 
 The COPYING file contains a copy of the license that your code is released under. For elementary OS apps this is typically the [GNU General Public License](http://www.gnu.org/licenses/quick-guide-gplv3.html) (GPL). Remember the header we added to our source code? That header reminds people that your app is licensed and it belongs to you. You can choose other licenses like the MIT license as well, but for this example let's stick to the [GPL](http://www.gnu.org/licenses/gpl-3.0.txt).


### PR DESCRIPTION
This looks like a convention from GNU, and the GNU docs explain it in a bit more detail than I think we want to get into here, but linking there could be useful.

Ready for review.
