### PR TITLE
Adjust docs CSS

### DIFF
--- a/_styles/docs.css
+++ b/_styles/docs.css
@@ -47,6 +47,52 @@ h6 a.heading-link:hover::before {
     top: 0.5em;
 }
 
+h2,
+h3,
+h4 {
+    line-height: 1.25;
+    margin-top: 24px;
+    margin-bottom: 16px;
+    text-align: left;
+}
+
+h1 {
+    font-family: 'Open Sans';
+    font-weight: 600;
+    margin-bottom: 1em;
+}
+
+h2 {
+    margin-top: 2em;
+    font-weight: 600;
+}
+
+h3 {
+    border-bottom: 1px solid #d4d4d4;
+    font-weight: 400;
+    opacity: 1;
+    padding-bottom: 0.3em;
+}
+
+h4 {
+    font-weight: 400;
+}
+
+p {
+    margin-top: 0;
+    margin-bottom: 1em;
+}
+
+p,
+li {
+    line-height: 1.5;
+}
+
+ol,
+ul {
+    padding-left: 2em;
+}
+
 .clear-float {
     clear: both;
     padding-top: 32px;
@@ -144,10 +190,6 @@ pre.highlighted .pre-numbering {
     padding: 0.5em;
     text-align: right;
     user-select: none;
-}
-
-p + p {
-    margin-top: 2em;
 }
 
 p + h1,

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -518,18 +518,6 @@ footer ul li a:focus {
     max-width: 800px;
 }
 
-.row.docs h2,
-.row.docs h3,
-.row.docs h4 {
-    margin-bottom: 16px;
-    margin-top: 32px;
-    text-align: left;
-}
-
-.row.docs h4 {
-    font-weight: 400;
-}
-
 /*******
 * Grid *
 *******/


### PR DESCRIPTION
The CSS that we're inheriting for the docs isn't really meant for long paragraphs and lots of sections. This overrides our default CSS and tries to make docs nicer to read by:

* Adding more space between sections
* Bolder headers
* Tightening spacing between paragraphs
* other minor spacing adjustments

**BEFORE**

![screenshot from 2017-12-13 12 16 11](https://user-images.githubusercontent.com/7277719/33960383-709b0bd4-dfff-11e7-8b22-b76f0744c939.png)


**AFTER**

![screenshot from 2017-12-13 12 15 56](https://user-images.githubusercontent.com/7277719/33960391-763cfd7c-dfff-11e7-865e-709138b2e58a.png)
