### PR TITLE
Full project name in debian/control example

### DIFF
--- a/docs/code/getting-started.md
+++ b/docs/code/getting-started.md
@@ -506,7 +506,7 @@ Now it's time to create the rules that will allow your app to be built as a .deb
 
 4. Open the file called "control" and make it look like below:
 
-        Source: hello-packaging
+        Source: com.github.yourusername.yourrepositoryname
         Section: x11
         Priority: extra
         Maintainer: Your Name <you@emailaddress.com>
@@ -516,7 +516,7 @@ Now it's time to create the rules that will allow your app to be built as a .deb
                        valac-0.26 | valac (>= 0.26)
         Standards-Version: 3.9.3
 
-        Package: hello-packaging
+        Package: com.github.yourusername.yourrepositoryname
         Architecture: any
         Depends: ${misc:Depends}, ${shlibs:Depends}
         Description: Hey young world


### PR DESCRIPTION
Prevents people from getting common "Warnings about Debian control file" issue when submitting app. 

This pull request is ready for review.
