### PR TITLE
Disable bitcoin payments

### DIFF
--- a/_scripts/widgets/payment.js
+++ b/_scripts/widgets/payment.js
@@ -87,7 +87,7 @@ export default class Payment {
                     description: this.description,
                     locale: this.language,
 
-                    bitcoin: true,
+                    bitcoin: false,
                     alipay: false,
 
                     currency,


### PR DESCRIPTION
We keep having problems with customers being automatically refunded due to bad transaction fees bids and timeouts etc. Just not supporting bitcoin would save some customer support time and Stripe is discontinuing it anyways