### PR TITLE
Fix #1926: Some sentences in support.php which actually should be tra…

### DIFF
--- a/support.php
+++ b/support.php
@@ -46,12 +46,12 @@ include $template['alert'];
 
     <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/geary" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/internet-mail.svg" alt="Mail"/>
-        <span data-l10n-off>Mail</span>
+        <span>Mail</span>
     </a>
 
     <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/epiphany" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/web-browser.svg" alt="Epiphany"/>
-        <span data-l10n-off>Epiphany</span>
+        <span>Epiphany</span>
     </a>
 
     <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/noise" target="_blank" rel="noopener">
@@ -66,7 +66,7 @@ include $template['alert'];
 
     <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/scratch" target="_blank" rel="noopener">
         <img width="64" height="64" src="images/icons/apps/64/accessories-text-editor.svg" alt="Text Editor"/>
-        <span data-l10n-off>Scratch</span>
+        <span>Scratch</span>
     </a>
 
     <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/settings" target="_blank" rel="noopener">


### PR DESCRIPTION
### Fix #1926: Some sentences in support.php which actually should be translatable are not translatable

Some strings in support.php were set as not translatable (the "data-l10n-off" tag) and could not translate.
Some languages or strings use the same app's name used in English (e.g.  Scratch --> Scratch). However, there are other languages or strings which translate them (e.g. in Japanese, Mail --> メール). So I think it is necessary to set these strings translatable.

### Changes Summary

- Deleted the tag "data-l10n-off" of the string "Mail" in line 49 of support.php
- Deleted the tag "data-l10n-off" of the string "Epiphany" in line 54 of support.php
- Deleted the tag "data-l10n-off" of the string "Scratch" in line 69 of support.php

This pull request is ready for review.
