### PR TITLE
Clarify labels of buttons/sections in "Get involved" page

### DIFF
--- a/_styles/get-involved.css
+++ b/_styles/get-involved.css
@@ -97,23 +97,23 @@ section {
     background-color: #44bbb2;
 }
 
-/* Support */
+/* User support */
 
-#support .button.flat.suggested-action {
+#user-support .button.flat.suggested-action {
     background-color: #d53c12;
 }
 
-#support .button.flat.suggested-action:focus {
+#user-support .button.flat.suggested-action:focus {
     background-color: #ef562c;
 }
 
-/* Web */
+/* Website */
 
-#web-development .button.flat.suggested-action {
+#website .button.flat.suggested-action {
     background-color: #d33682;
 }
 
-#web-development .button.flat.suggested-action:focus {
+#website .button.flat.suggested-action:focus {
     background-color: #ed509c;
 }
 

--- a/get-involved.php
+++ b/get-involved.php
@@ -29,9 +29,9 @@
         <div class="whole" id="sections-menu">
             <a class="button flat suggested-action" href="#funding">Funding</a>
             <a class="button flat suggested-action" href="#translations">Translations</a>
-            <a class="button flat suggested-action" href="#support">Support</a>
-            <a class="button flat suggested-action" href="#web-development">Web</a>
-            <a class="button flat suggested-action" href="#desktop-development">Desktop</a>
+            <a class="button flat suggested-action" href="#user-support">User support</a>
+            <a class="button flat suggested-action" href="#website">Website</a>
+            <a class="button flat suggested-action" href="#development">Development</a>
             <a class="button flat suggested-action" href="#design">Design</a>
         </div>
     </div>
@@ -101,7 +101,7 @@
     </div>
 </section>
 
-<section id="support" class="grey">
+<section id="user-support" class="grey">
     <div class="grid">
         <div class="two-thirds">
             <h2>Support</h2>
@@ -128,7 +128,7 @@
     </div>
 </section>
 
-<section id="web-development">
+<section id="website">
     <div class="web-browser">
         <div id="toolbar">
             <img src="images/get-involved/browser-left.svg">
@@ -144,7 +144,7 @@
     </div>
 </section>
 
-<section id="desktop-development" class="grey">
+<section id="development" class="grey">
     <div class="grid">
         <div class="two-thirds">
             <h2>Desktop Development</h2>


### PR DESCRIPTION
The choice of labels for some of the ways to get involved with the project were a bit ambiguous:

- "Support" is a very generic term, and can mean anything from financial contributions to helpdesk work. Changed to the more explicit "User Support".
- "Web" and "Desktop" are vague and unclear terms when not accompanied by the "development" suffix. Changed to "Website" and "Development", which IMO makes both meanings clearer in this context.

### Screenshots

Before:

![screenshot-2018-5-13 get involved with elementary os 2](https://user-images.githubusercontent.com/478237/39971326-01863a5c-56f1-11e8-9494-29e4c7d8530c.png)

----

After:

![screenshot-2018-5-13 get involved with elementary os](https://user-images.githubusercontent.com/478237/39971328-01d8d1a4-56f1-11e8-9d26-7a87cdef6e0d.png)

-----

Alternative (using one-word labels for all buttons):

![screenshot-2018-5-13 get involved with elementary os 1](https://user-images.githubusercontent.com/478237/39971327-01aabbb6-56f1-11e8-8330-a1ebcb86fbf5.png)

