### PR TITLE
Increase download timeout (again)

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -198,12 +198,12 @@ Promise.all([config, jQuery, Payment, modal]).then(([config, $, Payment]) => {
             $openModal.click()
         }
 
-        //  ACTION: redirectToThankYouPage: redirect to the thank-you page after 1.5 seconds (necessary due magnet-link)
+        //  ACTION: redirectToThankYouPage: redirect to the thank-you page after 3 seconds (necessary due magnet-link)
         // NOTE: This is a race condition with the download link headers
         function redirectToThankYouPage () {
             setTimeout(function () {
                 window.location.href = 'thank-you'
-            }, 1500)
+            }, 3000)
         }
 
         console.log('Loaded download.js')


### PR DESCRIPTION
It seems like we're still having customers that are having trouble with this redirect race condition business. Increase the timeout even more to try to avoid this