### PR TITLE
Add code icon and use it in docs

### DIFF
--- a/_images/thirdparty-icons/apps/128/io.elementary.code.svg
+++ b/_images/thirdparty-icons/apps/128/io.elementary.code.svg
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3828">
+  <defs
+     id="defs3830">
+    <linearGradient
+       x1="25.728966"
+       y1="0.55226636"
+       x2="25.728966"
+       y2="46.156921"
+       id="linearGradient5157"
+       xlink:href="#linearGradient3977-7-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.891892,0,0,2.3243242,7.59461,12.716354)" />
+    <linearGradient
+       id="linearGradient3977-7-8">
+      <stop
+         id="stop3979-6-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-3-70"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983-8-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985-2-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.284401"
+       y2="51.42194"
+       id="linearGradient5165"
+       xlink:href="#linearGradient4337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1142792,0,0,1.9120949,-8.742685,19.676374)" />
+    <radialGradient
+       cx="19.53446"
+       cy="40.430397"
+       r="23.929714"
+       fx="19.53446"
+       fy="40.430397"
+       id="radialGradient3846"
+       xlink:href="#linearGradient5071-7-3-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9222962,0,0,0.16715632,26.448985,114.23354)" />
+    <linearGradient
+       id="linearGradient5071-7-3-5">
+      <stop
+         id="stop5073-2-9-7"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5075-2-1-0"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5736">
+      <stop
+         offset="0"
+         style="stop-color:#586e75;stop-opacity:1"
+         id="stop5738" />
+      <stop
+         offset="1"
+         style="stop-color:#073642;stop-opacity:1"
+         id="stop5740" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4337">
+      <stop
+         offset="0"
+         style="stop-color:#fdf6e3;stop-opacity:1"
+         id="stop4339" />
+      <stop
+         offset="1"
+         style="stop-color:#eee8d5;stop-opacity:1"
+         id="stop4341" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient5736"
+       id="linearGradient5857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9813606,0.79277801,-0.48877088,1.8105292,4.92847,-4.3609206)"
+       x1="17.233864"
+       y1="-1.6629155"
+       x2="26.343443"
+       y2="54.477512" />
+    <linearGradient
+       y2="51.42194"
+       x2="25.284401"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(3.1142792,0,0,1.9120949,-8.742685,19.676374)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4527"
+       xlink:href="#linearGradient5736" />
+    <linearGradient
+       y2="46.156921"
+       x2="25.728966"
+       y1="0.55226636"
+       x1="25.728966"
+       gradientTransform="matrix(2.891892,0,0,2.3243242,7.59461,12.716354)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4529"
+       xlink:href="#linearGradient3977-7-8" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="rotate(-5,47.403766,98.596334)"
+     id="g4525">
+    <path
+       style="display:inline;fill:url(#linearGradient4527);fill-opacity:1;stroke:#001921;stroke-linejoin:round;stroke-opacity:0.49803922"
+       id="path4521"
+       d="M 105.49501,121.49988 22.500005,121.5 V 12.5 H 105.5 Z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4529);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:0.3"
+       id="path4523"
+       d="m 104.5,120.5001 h -81 V 13.500116 h 81 z" />
+  </g>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient3846);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992168;marker:none;enable-background:accumulate"
+     id="path5050-4"
+     d="m 110,120.99172 a 46,4.0000031 0 0 1 -91.999998,0 46,4.0000031 0 1 1 91.999998,0 z" />
+  <g
+     id="g4519">
+    <path
+       d="M 105.49501,121.49988 22.500005,121.5 V 12.5 H 105.5 Z"
+       id="path4160-9-6"
+       style="display:inline;fill:url(#linearGradient5165);fill-opacity:1;stroke:#aa8e37;stroke-linejoin:round;stroke-opacity:0.49803922" />
+    <path
+       d="m 104.5,120.5001 h -81 V 13.500116 h 81 z"
+       id="rect6741-1-2-83"
+       style="fill:none;stroke:url(#linearGradient5157);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <path
+     style="opacity:0.2;fill:none;stroke:#aa8e37;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path3715"
+     d="m 32,29.5 h 6.261052 m 0.894438,0 h 5.813834 m 0.935853,0 h 5.187729 m 0.85302,0 h 2.236088 m 0.894437,0 h 5.008842 m 0.98388,0 h 13.148209 m 0.894441,0 h 10.017683 m 0.894436,0 h 3.041082 M 32,34.5 h 9.70804 m 1.129462,0 h 4.638723 m 0.85751,0 h 2.289126 m 0.931362,0 h 4.272945 m 0.894439,0 h 4.382114 m 0.827201,0 h 6.880954 m 0.894441,0 h 9.077596 M 32,39.47337 h 8.216874 m 0.863183,0 h 13.532462 m 0.829388,0 h 6.562951 m 0.84118,0 H 68.9856 m 0.880455,0 h 5.230022 m 0.841183,0 8.225503,0.05326 M 32,44.5 h 11.424571 m 0.897126,0 h 12.34781 m 0.853021,0 h 4.85227 m 0.894438,0 h 11.5493 m 0.77734,0 h 7.915841 m 0.89444,0 h 3.132991 m 0.894438,0 h 1.732989 M 32,49.5 h 4.26449 m 1.310208,0 H 53.364854 M 32,76.5 h 9.70804 m 1.129462,0 h 4.638723 m 0.85751,0 h 2.289126 m 0.931362,0 h 4.272945 m 0.894439,0 h 4.382114 m 0.827201,0 h 6.880954 M 32,87.418189 h 8.216874 m 0.863183,0 h 13.532462 m 0.829388,0 h 6.562951 m 23.192051,0.163622 H 98.601537 M 32,71.5 h 11.424571 m 0.897126,0 h 12.34781 m 0.853021,0 h 4.85227 m 0.894438,0 h 11.5493 M 32,60.5 h 6.261052 m 0.894438,0 h 5.813834 m 0.935853,0 h 5.187729 m 0.85302,0 h 2.236088 m 0.894437,0 h 5.008842 m 0.98388,0 h 13.148209 m 0.894441,0 H 85.129506 M 32,66.5 h 10.544418 m 0.829422,0 h 11.196841 m 0.853021,0 h 4.378342 m 0.826736,0 h 10.533738 m 0.845044,0 H 83.511717 M 32,92.5 h 9.853568 m 1.057734,0 h 4.344169 m 1.017501,0 h 2.166749 m 0.689724,0 h 4.277289 m 0.567845,0 h 22.644829 m 1.065528,0 h 6.044827 m 0.812792,0 h 1.526282 m -44.843223,6 h 3.21427 M 32,98.5 h 10.284685 m 4.977259,0 h 7.478552 m 0.791095,0 h 10.978052 m 0.85302,0 h 7.447382 m 0.74968,0 h 1.534646 m 0.839123,0 h 9.456876 m 0.96682,0 h 4.951147 m -50.082723,5 h 4.538384 M 32,103.5 h 10.284685 m 6.462851,0 h 6.380506" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:19px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Semi-Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 54,54 c -2.89074,2.8e-5 -4.42298,0.428249 -5.875,1.3125 C 46.68628,56.184851 46,57.573372 46,59.4375 V 65 c 0,1.111334 -0.4958,1.88783 -1.375,2.4375 -0.86588,0.537751 -2.82662,0.875011 -4.625,0.875 v 3.375 c 3.54346,8e-6 6,1.152366 6,3.375 v 5.0625 c 0,2.043394 0.65454,3.591819 2,4.5 1.35876,0.920118 2.92276,1.351094 6,1.375 V 82.75 C 52.46804,82.7261 51.67938,82.439383 51,81.9375 50.3206,81.435614 50,80.729873 50,79.75 v -5.375 c 0,-2.401881 -1.19942,-3.819803 -4.25,-4.25 v -0.25 C 48.80058,69.408974 50,67.940502 50,65.5625 V 60.25 c 0,-0.979855 0.3206,-1.635041 1,-2.125 0.6927,-0.501864 1.48136,-0.81523 3,-0.875 z m 20,0 v 3.25 c 1.51864,0.05978 2.3073,0.373136 3,0.875 0.6794,0.48996 1,1.145145 1,2.125 v 5.3125 c 0,2.378002 1.19942,3.846474 4.25,4.3125 v 0.25 C 79.19942,70.555197 78,71.973119 78,74.375 v 5.375 c 0,0.979873 -0.3206,1.685614 -1,2.1875 -0.67938,0.501883 -1.46804,0.7886 -3,0.8125 V 86 c 3.07724,-0.0239 4.64124,-0.454882 6,-1.375 1.34546,-0.908181 2,-2.456606 2,-4.5 v -5.0625 c 0,-2.222634 2.45654,-3.374992 6,-3.375 v -3.375 c -1.79838,1.2e-5 -3.75912,-0.337249 -4.625,-0.875 C 82.495799,66.88783 82,66.111334 82,65 V 59.4375 C 82,57.573372 81.313699,56.184851 79.875,55.3125 78.42298,54.428249 76.89074,54.000028 74,54 Z"
+     id="path4550" />
+  <path
+     id="path3873-9"
+     d="m 54,53 c -2.89074,2.8e-5 -4.42298,0.428249 -5.875,1.3125 C 46.68628,55.184851 46,56.573372 46,58.4375 V 64 c 0,1.111334 -0.4958,1.88783 -1.375,2.4375 -0.86588,0.537751 -2.82662,0.875011 -4.625,0.875 v 3.375 c 3.54346,8e-6 6,1.152366 6,3.375 v 5.0625 c 0,2.043394 0.65454,3.591819 2,4.5 1.35876,0.920118 2.92276,1.351094 6,1.375 V 81.75 C 52.46804,81.7261 51.67938,81.439383 51,80.9375 50.3206,80.435614 50,79.729873 50,78.75 v -5.375 c 0,-2.401881 -1.19942,-3.819803 -4.25,-4.25 v -0.25 C 48.80058,68.408974 50,66.940502 50,64.5625 V 59.25 c 0,-0.979855 0.3206,-1.635041 1,-2.125 0.6927,-0.501864 1.48136,-0.81523 3,-0.875 z m 20,0 v 3.25 c 1.51864,0.05978 2.3073,0.373136 3,0.875 0.6794,0.48996 1,1.145145 1,2.125 v 5.3125 c 0,2.378002 1.19942,3.846474 4.25,4.3125 v 0.25 C 79.19942,69.555197 78,70.973119 78,73.375 v 5.375 c 0,0.979873 -0.3206,1.685614 -1,2.1875 -0.67938,0.501883 -1.46804,0.7886 -3,0.8125 V 85 c 3.07724,-0.0239 4.64124,-0.454882 6,-1.375 1.34546,-0.908181 2,-2.456606 2,-4.5 v -5.0625 c 0,-2.222634 2.45654,-3.374992 6,-3.375 v -3.375 c -1.79838,1.2e-5 -3.75912,-0.337249 -4.625,-0.875 C 82.495799,65.88783 82,65.111334 82,64 V 58.4375 C 82,56.573372 81.313699,55.184851 79.875,54.3125 78.42298,53.428249 76.89074,53.000028 74,53 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:19px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Semi-Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5857);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+</svg>

--- a/_images/thirdparty-icons/apps/64/io.elementary.code.svg
+++ b/_images/thirdparty-icons/apps/64/io.elementary.code.svg
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg3130">
+  <defs
+     id="defs3132">
+    <linearGradient
+       id="linearGradient5769">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop5771" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop5773" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop5775" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop5777" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5736">
+      <stop
+         offset="0"
+         style="stop-color:#586e75;stop-opacity:1"
+         id="stop5738" />
+      <stop
+         offset="1"
+         style="stop-color:#073642;stop-opacity:1"
+         id="stop5740" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4337">
+      <stop
+         offset="0"
+         style="stop-color:#fdf6e3;stop-opacity:1"
+         id="stop4339" />
+      <stop
+         offset="1"
+         style="stop-color:#eee8d5;stop-opacity:1"
+         id="stop4341" />
+    </linearGradient>
+    <linearGradient
+       x1="41.45314"
+       y1="-3.7500122"
+       x2="41.45314"
+       y2="42.059517"
+       id="linearGradient4277-0"
+       xlink:href="#linearGradient5769"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.135135,-0.37882,10.25677)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient4285-6"
+       xlink:href="#linearGradient4337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5714252,0,0,0.95604679,-3.7142,13.088186)" />
+    <radialGradient
+       cx="19.53446"
+       cy="40.430397"
+       r="23.929714"
+       fx="19.53446"
+       fy="40.430397"
+       id="radialGradient4291-0"
+       xlink:href="#radialGradient3109-470-9-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0029562,1.769214e-7,-1.4743171e-8,0.0835781,14.407338,56.620897)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       id="radialGradient3109-470-9-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,19.694118)">
+      <stop
+         id="stop5165-6-1"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5167-3-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       xlink:href="#linearGradient5736"
+       id="linearGradient5857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5163817,0.4032233,-0.24859898,0.92087263,3.95455,0.18711795)"
+       x1="17.233864"
+       y1="-1.6629155"
+       x2="26.343443"
+       y2="54.477512" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.5714252,0,0,0.95604679,-5.7142,12.90359)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4523"
+       xlink:href="#linearGradient5736" />
+    <linearGradient
+       y2="42.059517"
+       x2="41.45314"
+       y1="-3.7500122"
+       x1="41.45314"
+       gradientTransform="matrix(1.4324324,0,0,1.135135,-4.37882,8.25677)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4677"
+       xlink:href="#linearGradient5769" />
+  </defs>
+  <metadata
+     id="metadata3135">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="rotate(-5,44.653569,3.6722725)"
+     id="g4688">
+    <path
+       style="display:inline;fill:url(#linearGradient4523);fill-opacity:1;stroke:#001921;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.50196078"
+       id="path4521"
+       d="m 51.50047,2.5365013 c 10e-7,12.6032927 -0.003,54.9999417 -0.003,54.9999417 l -42.9969715,5.9e-5 c 0,0 10e-7,-36.666668 -2e-7,-55.0000007 14.3333197,0 28.6666417,-10e-8 42.9999597,0 z" />
+    <path
+       style="opacity:0.3;fill:none;stroke:url(#linearGradient4677);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4673"
+       d="M 9.500001,56.499999 V 3.4999991 h 41 V 56.499999 Z" />
+  </g>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4291-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992174;marker:none;enable-background:accumulate"
+     id="path5050-1-5"
+     d="m 57.99955,60 a 24,2.0000002 0 0 1 -48,0 24,2.0000002 0 1 1 48,0 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient4285-6);fill-opacity:1;stroke:#aa8e37;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.50196078"
+     id="path4160-9-48-5"
+     d="m 55.500451,4.4999991 c 0,12.6032899 -0.003,54.9999399 -0.003,54.9999399 l -42.996971,6e-5 c 0,0 0,-36.66667 0,-54.9999999 14.33332,0 28.66664,0 42.99996,0 z" />
+  <path
+     style="opacity:0.2;fill:none;stroke:#aa8e37;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path3715"
+     d="m 17,12.5 h 3.1305 m 0.447215,0 h 2.906893 m 0.467923,0 h 2.593843 m 0.426507,0 h 1.118035 m 0.447215,0 h 2.5044 m 0.491936,0 h 6.574051 m 0.447217,0 h 5.0088 m 0.447215,0 h 1.520528 M 17,15.5 h 4.85398 m 0.564726,0 h 2.319342 m 0.428752,0 h 1.144554 m 0.465677,0 h 2.136455 m 0.447216,0 h 2.191039 m 0.413597,0 h 3.440449 m 0.447217,0 h 4.53876 M 17,18.486685 h 4.108403 m 0.431588,0 h 6.766176 m 0.41469,0 h 3.281449 m 0.420587,0 h 3.069756 m 0.440223,0 h 2.614989 m 0.420589,0 4.112718,0.02663 M 17,21.5 h 5.712238 m 0.448559,0 h 6.173855 m 0.426507,0 h 2.426115 m 0.447216,0 h 5.774602 m 0.388667,0 h 3.957889 m 0.447216,0 h 1.566482 m 0.447216,0 h 0.866487 M 17,24.5 h 2.132227 m 0.655099,0 h 7.895013 M 17,37.5 h 4.85398 m 0.564726,0 h 2.319342 m 0.428752,0 h 1.144554 m 0.465677,0 h 2.136455 m 0.447216,0 h 2.191039 m 0.413597,0 h 3.440449 M 17,41.459095 h 4.108403 m 0.431588,0 h 6.766176 m 0.41469,0 h 3.281449 m 11.59593,0.08181 h 6.70226 M 17,34.5 h 5.712238 m 0.448559,0 h 6.173855 m 0.426507,0 h 2.426115 m 0.447216,0 h 5.774602 M 17,28.5 h 3.1305 m 0.447215,0 h 2.906893 m 0.467923,0 h 2.593843 m 0.426507,0 h 1.118035 m 0.447215,0 h 2.5044 m 0.491936,0 h 6.574051 m 0.447217,0 h 5.0088 M 17,31.5 h 5.272165 m 0.414708,0 h 5.598375 m 0.426507,0 h 2.189153 m 0.413364,0 h 5.266826 m 0.422519,0 h 5.752031 M 17,44.500488 h 4.926743 m 0.528863,0 h 2.172067 m 0.508746,0 h 1.083366 m 0.344859,0 h 2.138627 m 0.283921,0 h 11.322321 m 0.53276,0 h 3.022388 m 0.406393,0 h 0.763135 M 22.612761,47.5 h 1.607122 M 17,47.5 h 5.1423 m 2.488609,0 h 3.739246 m 0.395544,0 h 5.488981 m 0.426507,0 h 3.72366 m 0.374837,0 h 0.767317 m 0.419558,0 h 4.7284 m 0.483405,0 h 2.475554 m -25.041157,3 h 2.269174 M 17,50.5 h 5.1423 m 3.231399,0 h 3.190227" />
+  <path
+     style="fill:none;stroke:url(#linearGradient4277-0);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-2-3-4"
+     d="M 13.500001,58.499999 V 5.4999991 h 41 V 58.499999 Z" />
+  <path
+     id="path4517"
+     d="m 39.000465,24.999999 c 1.44537,1.4e-5 2.21149,0.214124 2.9375,0.65625 0.71935,0.436176 1.0625,1.130436 1.0625,2.0625 v 2.78125 c 0,0.555667 0.2479,0.943915 0.6875,1.21875 0.43294,0.268875 1.41331,0.437506 2.3125,0.4375 v 1.6875 c -1.77173,4e-6 -3,0.576183 -3,1.6875 v 2.53125 c 0,1.021697 -0.32727,1.79591 -1,2.25 -0.67938,0.46006 -1.46139,0.675547 -3,0.6875 v -1.625 c 0.76598,-0.01195 1.16031,-0.155308 1.5,-0.40625 0.3397,-0.250943 0.5,-0.603813 0.5,-1.09375 v -2.6875 c 0,-1.20094 0.59971,-1.909901 2.125,-2.125 v -0.125 c -1.52529,-0.233013 -2.125,-0.967249 -2.125,-2.15625 v -2.65625 c 0,-0.489927 -0.1603,-0.81752 -0.5,-1.0625 -0.34635,-0.250932 -0.74068,-0.407615 -1.5,-0.4375 z m -10,0 v 1.625 c -0.75932,0.02989 -1.15365,0.186568 -1.5,0.4375 -0.3397,0.24498 -0.5,0.572573 -0.5,1.0625 v 2.65625 c 0,1.189001 -0.59972,1.923237 -2.125,2.15625 v 0.125 c 1.52528,0.215099 2.125,0.92406 2.125,2.125 v 2.6875 c 0,0.489937 0.1603,0.842807 0.5,1.09375 0.33969,0.250942 0.73402,0.3943 1.5,0.40625 v 1.625 c -1.53862,-0.01195 -2.32062,-0.22744 -3,-0.6875 -0.67273,-0.45409 -1,-1.228303 -1,-2.25 v -2.53125 c 0,-1.111317 -1.22827,-1.687496 -3,-1.6875 v -1.6875 c 0.89919,6e-6 1.87955,-0.168625 2.3125,-0.4375 0.4396,-0.274835 0.6875,-0.663083 0.6875,-1.21875 v -2.78125 c 0,-0.932064 0.34314,-1.626324 1.0625,-2.0625 0.72601,-0.442126 1.49213,-0.656236 2.9375,-0.65625 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:19px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Semi-Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:19px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Semi-Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient5857);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 29.000465,23.999999 c -1.44537,1.4e-5 -2.21149,0.214124 -2.9375,0.65625 -0.71935,0.436176 -1.0625,1.130436 -1.0625,2.0625 v 2.78125 c 0,0.555667 -0.2479,0.943915 -0.6875,1.21875 -0.43294,0.268875 -1.41331,0.437506 -2.3125,0.4375 v 1.6875 c 1.77173,4e-6 3,0.576183 3,1.6875 v 2.53125 c 0,1.021697 0.32727,1.79591 1,2.25 0.67938,0.46006 1.46139,0.675547 3,0.6875 v -1.625 c -0.76598,-0.01195 -1.16031,-0.155308 -1.5,-0.40625 -0.3397,-0.250943 -0.5,-0.603813 -0.5,-1.09375 v -2.6875 c 0,-1.20094 -0.59971,-1.909901 -2.125,-2.125 v -0.125 c 1.52529,-0.233013 2.125,-0.967249 2.125,-2.15625 v -2.65625 c 0,-0.489927 0.1603,-0.81752 0.5,-1.0625 0.34635,-0.250932 0.74068,-0.407615 1.5,-0.4375 z m 10,0 v 1.625 c 0.75932,0.02989 1.15365,0.186568 1.5,0.4375 0.3397,0.24498 0.5,0.572573 0.5,1.0625 v 2.65625 c 0,1.189001 0.59972,1.923237 2.125,2.15625 v 0.125 c -1.52528,0.215099 -2.125,0.92406 -2.125,2.125 v 2.6875 c 0,0.489937 -0.1603,0.842807 -0.5,1.09375 -0.33969,0.250942 -0.73402,0.3943 -1.5,0.40625 v 1.625 c 1.53862,-0.01195 2.32062,-0.22744 3,-0.6875 0.67273,-0.45409 1,-1.228303 1,-2.25 v -2.53125 c 0,-1.111317 1.22827,-1.687496 3,-1.6875 v -1.6875 c -0.89919,6e-6 -1.87955,-0.168625 -2.3125,-0.4375 -0.4396,-0.274835 -0.6875,-0.663083 -0.6875,-1.21875 v -2.78125 c 0,-0.932064 -0.34314,-1.626324 -1.0625,-2.0625 -0.72601,-0.442126 -1.49213,-0.656236 -2.9375,-0.65625 z"
+     id="path3873-9-5-7" />
+</svg>

--- a/docs/code/getting-started.md
+++ b/docs/code/getting-started.md
@@ -68,7 +68,7 @@ At the time of this writing, elementary OS doesn't have a full SDK like Android 
 
 ### Code {#code}
 
-![](images/icons/apps/128/accessories-text-editor.svg)
+![](images/thirdparty-icons/apps/128/io.elementary.code.svg)
 
 The first piece of our simple "SDK" is Code. This comes by default with elementary OS. It comes with some helpful features like syntax highlighting, auto-save, and a Folder Manager. There are other extensions for Code as well, like the Outline, Terminal, Word Completion, or Devhelp extensions. Play around with what works best for you.
 


### PR DESCRIPTION
Adds the code icon (including an extra size that will be used once Juno goes stable) and use it in the docs (since those are written against beta)