### PR TITLE
Update Translation Guide

### DIFF
--- a/docs/translation-guide.md
+++ b/docs/translation-guide.md
@@ -2,35 +2,39 @@
 
 Localizing our website and apps is a very important part of making elementary OS available to as many people as possible. Instead of relying solely on an internal translation team, we use crowdsourcing so that anyone can submit translations with little to no technical knowledge. In order to keep our voice consistent across the entire platform, and to help new translators get started, we’ve put together this translation guide.
 
-## Translating Applications {#translating-applications}
+<span id="translating-applications"/>
+<span id="translating-our-website"/>
+## Steps to Begin Translation {#steps-to-begin-translation}
 
-Apps are translated through Weblate: a free web-based translation management system.. In order to submit translations, you should:
+Our apps and website are translated through Weblate: a free web-based translation management system. In order to submit translations, you should:
 
 * Have a [Weblate account](https://l10n.elementary.io/accounts/register/)
 * Set your [language preferences](https://l10n.elementary.io/accounts/profile/)
 * Browse our [translatable projects](https://l10n.elementary.io/projects/)
 
-Once you’ve selected a project, you can provide suggestions for strings that have not yet been translated, or suggest changes to strings that have already been translated. These suggestions will be evaluated by a translation team member and they will choose the most appropriate one. For a more information about Weblate, you can refer to their [documentation](https://docs.weblate.org/en/weblate-2.15/index.html).
+Once you’ve selected a project, you can provide suggestions for strings that have not yet been translated, or suggest changes to strings that have already been translated. These suggestions will be evaluated by a translation team member and they will choose the most appropriate one. For a more information about Weblate, you can refer to their [documentation](https://docs.weblate.org/en/weblate-3.0.1/user/index.html).
+
+By default, you're only able to suggest translations. If you would like to get permissions to save translations, [join the translators Slack](https://ele-l10n.slack.com/join/shared_invite/enQtMjkwMjI2Mzk5ODQxLWM3NWZlMjMxMTUyNzg0MjdiNTdkYTM5ZDA3NzE5YTIwMzZmZjhmZjg0MzQwMGE5MjVhMGU2Yjk2MDU1MGZiYTU) and ask administrators there.
 
 When translating you may encounter a situation where you have to decide between several ways of saying the same thing. In these situations we refer to the Ubuntu [general translator guide](https://help.launchpad.net/Translations/Guide), and for language specific issues we follow Ubuntu's [team translation guidelines](https://translations.launchpad.net/+groups/ubuntu-translators). Following these guides ensure uniform translations, while also allowing anyone to contribute.
 
-If you don't want to use Weblate, or want to make a lot a changes at once, you can also translate offline. To do so:
+If you don't want to translate using Weblate, or want to make a lot a changes at once, you can also translate offline. To do so:
 
 * Go to a project you want to translate
 * Choose your language
-* Click on "Download translation"
-
-You are now able to request an e-mail, which gives you the right link to download the translations. Now:
-
-* Choose your favorite text- or po-editor (e.g. [Poedit](https://apps.ubuntu.com/cat/applications//poedit/))
+* Click on "Files" and then select "Download translation as gettext PO"
+* Choose your favorite text-, code- or po-editor (e.g. [Poedit](https://poedit.net/))
 * Start translating
 
-Once you've finished, use the "Upload translation" option on the same page that you downloaded them from.
+Once you've finished, use the "Upload translation" option in the "Files" menu on the same page that you downloaded them from.
 
-## Translating our Website {#translating-our-website}
+## Additional Information {#additional-information}
 
-Our website is also translated through [Weblate](https://l10n.elementary.io/projects/website/). In order to submit translations, you should have a [Weblate account](https://l10n.elementary.io/accounts/register/)
+We won't support translations in the following pages:
 
-For more information about Weblate, you can refer to their [documentation](https://docs.weblate.org/en/latest/).
-
-As with our apps, we follow Ubuntu’s [general translator guide](https://help.launchpad.net/Translations/Guide), and for language specific issues we follow Ubuntu's [team translation guidelines](https://translations.launchpad.net/+groups/ubuntu-translators).
+* <a href="https://developer.elementary.io" data-l10n-off="1">Developer</a>
+* <a href="https://elementary.io/docs/code/getting-started" data-l10n-off="1">Getting Started</a>
+* <a href="https://elementary.io/docs/code/reference" data-l10n-off="1">Reference</a>
+* <a href="https://elementary.io/docs/human-interface-guidelines" data-l10n-off="1">Human Interface Guidlines</a>
+* <a href="https://elementary.io/store/" data-l10n-off="1">Store</a>
+* <a href="https://elementary.io/team" data-l10n-off="1">Team</a>


### PR DESCRIPTION
Fixes #1848

### Changes Summary

- Delete an unneeded period
- Merge the two instructions for apps and the website into one
- Update how to translate in local
- Delete outdated instructions that were applicable to Launchpad
- Add the link to join translators team and specify that translators must ask some admin in Slack (This was also mentioned in #1932)
- Update the link to Weblate documentation to the current version (hardcoded 3.0.1)
- Clarify that there are some "won't support translation" pages, because some translators may ask or submit as a issue that they are not translatable (I'm not sure this change is appropriate and these pages truly won't support translations)

This pull request is ready for review.
