### PR TITLE
Remove the Thank You redirect on download

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -175,7 +175,6 @@ Promise.all([config, jQuery, Payment, modal]).then(([config, $, Payment]) => {
         $('.download-link').click(function () {
             ga('send', 'event', config.release.title + ' ' + config.release.version + ' Download (OS)', 'Homepage', detectedOS)
             ga('send', 'event', config.release.title + ' ' + config.release.version + ' Download (Region)', 'Homepage', config.user.region)
-            redirectToThankYouPage()
         })
         $('.download-link.http').click(function () {
             ga('send', 'event', config.release.title + ' ' + config.release.version + ' Download (Method)', 'Homepage', 'HTTP')
@@ -196,14 +195,6 @@ Promise.all([config, jQuery, Payment, modal]).then(([config, $, Payment]) => {
             })
             // This is what actually opens the modal overlay.
             $openModal.click()
-        }
-
-        //  ACTION: redirectToThankYouPage: redirect to the thank-you page after 1.5 seconds (necessary due magnet-link)
-        // NOTE: This is a race condition with the download link headers
-        function redirectToThankYouPage () {
-            setTimeout(function () {
-                window.location.href = 'thank-you'
-            }, 1500)
         }
 
         console.log('Loaded download.js')


### PR DESCRIPTION
Still getting lots of emails from customers having trouble downloading because of the race condition here. We should remove this for now until we can come up with a solution that doesn't have this problem