### PR TITLE
Remove about item from slingshot animation

### DIFF
--- a/data/slingshot.json
+++ b/data/slingshot.json
@@ -46,9 +46,6 @@
         {"title": "Settings", "items": [
             {"icon":"icons/categories/32/preferences-system-time","title":"<b>Da</b>te & Time"},
             {"icon":"icons/categories/32/preferences-desktop-display","title":"<b>D</b>ispl<b>a</b>ys"}
-        ]},
-        {"title": "Application Actions", "items": [
-            {"icon":"icons/apps/32/office-calendar","title":"About Calendar"}
         ]}
     ]
 ,


### PR DESCRIPTION
### Changes Summary

- Remove "About Calendar" from slingshot animation

## Before

![screenshot from 2018-08-08 17-15-14](https://user-images.githubusercontent.com/26003928/43825189-11a77a36-9b2f-11e8-99f6-f6323da18545.png)

## After

![screenshot from 2018-08-08 17-20-51](https://user-images.githubusercontent.com/26003928/43825353-84d8a6ec-9b2f-11e8-884d-b82be473d7c6.png)

This pull request is ready for review.
