### PR TITLE
Adds an id to EditorConfig doc section (just a doc fix)

### DIFF
--- a/docs/code/reference.md
+++ b/docs/code/reference.md
@@ -209,7 +209,7 @@ limit is 120 characters.
     * Authored by: Author <author@example.com>
     */
 
-## EditorConfig
+## EditorConfig {#editorconfig}
 
 If your code editor supports [EditorConfig](https://editorconfig.org/), you can use this as a default `.editorconfig` file in your projects:
 


### PR DESCRIPTION
Noticed while browsing around that the EditorConfig section in the code reference page appeared in the sidebar contents, but the sidebar link was to `#undefined` and clicking it bounced out to the main page. Looks like all that's missing is the `{#editorconfig}` after the heading, so here it is.

### Changes Summary

- adds id attribute into Markdown source

This pull request is ready for review.
