### PR TITLE
Rename screenshot-tool to screenshot

### DIFF
--- a/open-source.php
+++ b/open-source.php
@@ -42,7 +42,7 @@
             <a class="button sub-item" href="https://github.com/elementary/music" target="_blank" rel="noopener"><span>Music</span></a>
             <a class="button sub-item" href="https://github.com/elementary/photos" target="_blank" rel="noopener"><span>Photos</span></a>
             <a class="button sub-item" href="https://github.com/elementary/scratch" target="_blank" rel="noopener"><span>Scratch</span></a>
-            <a class="button sub-item" href="https://github.com/elementary/screenshot-tool" target="_blank" rel="noopener"><span>Screenshot Tool</span></a>
+            <a class="button sub-item" href="https://github.com/elementary/screenshot" target="_blank" rel="noopener"><span>Screenshot</span></a>
             <a class="button sub-item" href="https://github.com/elementary/terminal" target="_blank" rel="noopener"><span>Terminal</span></a>
             <a class="button sub-item" href="https://github.com/elementary/videos" target="_blank" rel="noopener"><span>Videos</span></a>
         </div>


### PR DESCRIPTION
Related https://github.com/elementary/screenshot/issues/85

### Changes Summary

- Update the GitHub URL for Screenshot
- Rename Screenshot Tool to Screenshot

This pull request is ready for review.
