### PR TITLE
remove google plus link from page header

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -145,7 +145,6 @@ $l10n->begin_html_translation();
                 </ul>
                 <ul class="right">
                     <li><a href="https://www.facebook.com/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Facebook"><i class="fab fa-facebook-f"></i></a></li>
-                    <li><a href="https://plus.google.com/+elementary" target="_blank" rel="noopener" data-l10n-off title="Google+"><i class="fab fa-google-plus-g"></i></a></li>
                     <li><a href="https://mastodon.social/@elementary" target="_blank" rel="noopener" data-l10n-off title="Mastodon"><i class="fab fa-mastodon"></i></a></li>
                     <li><a href="https://medium.com/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Medium"><i class="fab fa-medium-m"></i></a></li>
                     <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Reddit"><i class="fab fa-reddit"></i></a></li>


### PR DESCRIPTION
removed due to the announced shutdown of google plus

Fixes #

### Changes Summary

- removed google plus link from header.php due to the announced shutdown of google plus
- 
- 

This pull request [ **is** / is not ] ready for review.
