### PR TITLE
Previous downloads

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -10,6 +10,12 @@ $config = array(
     'release_size'     => '1.48 GB',
     'release_magnet'   => 'f5b31b1bd67bf65fe97be298ec7c473cb2e3e201',
 
+    'previous_title'    => 'Loki',
+    'previous_version'  => '0.4.1',
+    'previous_filename' => 'elementaryos-0.4.1-stable.20180214.iso',
+    'previous_size'     => '1.50 GB',
+    'previous_magnet'   => '54dca0477d74d88ed051a9cd62fe5359151e7823',
+
     'chart_enable'         => false,
     'chart_link_project'   => 'elementary',
     'chart_link_milestone' => 'loki-rc1',

--- a/api/config.php
+++ b/api/config.php
@@ -15,6 +15,11 @@ $output = array(
         'version' => $config['release_version']
     ),
 
+    'previous' => array(
+        'title' => $config['previous_title'],
+        'version' => $config['previous_version']
+    ),
+
     'keys' => array(
         'sentry' => $config['sentry_pub'],
         'stripe' => $config['stripe_pk']

--- a/api/download.php
+++ b/api/download.php
@@ -58,21 +58,37 @@ foreach ($products as $product) {
         if ($isoMajor != null) {
             // Set $currentMajor as the first number from the current release version
             list($currentMajor) = explode('.', $config['release_version']);
+            // Set $previousMajor as the first number from the previous release version
+            list($previousMajor) = explode('.', $config['previous_version']);
+
             // If the purchased major matches the current major
             if ($isoMajor == $currentMajor) {
                 // Override $isoVersion to match the current release,
                 // so long as it's only a minor upgrade.
                 $isoVersion = $config['release_version'];
+                // $isoVersion is either:
+                // 1. an outdated product that was purchased
+                // 2. a minor upgrade version to a product that was purchased
+                os_payment_setcookie($isoVersion, $charge['amount']);
+                go_home();
+
+            // If the purchased major matches the previous major
+            } else if ($isoMajor == $previousMajor) {
+                // Override $isoVersion to match the previous release,
+                // so long as it's only a minor upgrade.
+                $isoVersion = $config['previous_version'];
+                // $isoVersion is either:
+                // 1. an outdated product that was purchased
+                // 2. a minor upgrade version to a product that was purchased
+                os_payment_setcookie($isoVersion, $charge['amount']);
+                header('Location: ' . $sitewide['root'] . '/previous');
+                exit;
+
+            // Was too old or not determinable
+            } else {
+                go_home();
             }
+
         }
     }
 }
-
-// $isoVersion is either:
-// 1. an outdated product that was purchased
-// 2. a minor upgrade version to a product that was purchased
-if ($isoVersion !== false) {
-    os_payment_setcookie($isoVersion, $charge['amount']);
-}
-
-return go_home();

--- a/previous.php
+++ b/previous.php
@@ -1,0 +1,37 @@
+<?php
+    require_once __DIR__.'/_backend/preload.php';
+    $page['title'] = 'Thank You for Downloading elementary OS';
+    $page['theme-color'] = '#3E4E54';
+
+    $already_paid = (os_payment_getcookie($config['previous_version']) > 0);
+    if (!$already_paid) {
+        header("Location: " . $sitewide['root']);
+        exit;
+    } else {
+
+        include $template['header'];
+        include $template['alert'];
+?>
+
+<section class="hero">
+    <div class="grid">
+        <div class="two-thirds">
+            <h1>
+                Thank You for Downloading
+                <?php
+                    // Embed the SVG to fix scaling in WebKit 1.x,
+                    // while preserving CSS options for the image.
+                    include __DIR__.'/images/logotype-os.svg';
+                ?>
+            </h1>
+            <!-- TODO Add link to download previous version -->
+            <!-- TODO Add warning about outdated version -->
+            <p>For help and more info, read the <a href="<?php echo $sitewide['lang-root'];?>/docs/installation#installation">installation guide</a>. If you purchased elementary OS, check your email for a receipt that includes your link to download elementary OS again for free.</p>
+            <a class="button suggested-action" href="<?php echo $sitewide['lang-root'];?>/docs/installation#installation">Read Installation Guide</a>
+        </div>
+    </div>
+</section>
+
+<?php
+        include $template['footer'];
+    }


### PR DESCRIPTION
Fixes #2089

The design remit here is to allow users who paid for a previous release to still access their product, while pointing them to the newer release as well.

### Changes Summary

- Add config for previous release
- Add page to download previous release (paid users only)

This pull request is not ready for review.
