### PR TITLE
Catch NaN and do NOT try and make pay.

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -102,7 +102,7 @@ Promise.all([config, jQuery, Payment, modal]).then(([config, $, Payment]) => {
             var paymentAmount = $('#' + currentButton).val() * 100
             console.log('Starting payment for ' + paymentAmount)
             // Free download
-            if (paymentAmount < paymentMinimum) {
+            if (Number.isNaN(paymentAmount) || paymentAmount < paymentMinimum) {
                 ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Skip)', 'Homepage', paymentAmount)
                 // Open the Download modal immediately.
                 openDownloadOverlay()


### PR DESCRIPTION
Some users are seeing an old version of this script and the new version of the site. This catches the flaw where they mismatch and skips payment if it cannot determine a number to pay. We also need to make sure that https://elementary.io/scripts/download.js accurately reflects this change.

This pull request is ready for review.
