### PR TITLE
Stop misspelling Matthew Butterick’s name

### DIFF
--- a/docs/human-interface-guidelines.md
+++ b/docs/human-interface-guidelines.md
@@ -1412,7 +1412,7 @@ Use `\u2014` in code. Used for:
 
 ---
 
-If in doubt, refer to [Butterwick's Practical Typography](https://practicaltypography.com/).
+If in doubt, refer to [Butterick's Practical Typography](https://practicaltypography.com/).
 
 These rules apply to the English language; other languages may have their own conventions which should be followed by translators.
 


### PR DESCRIPTION
### Changes Summary

- For as long as I remember, this misspelling has been there, and I remember reporting it back when you allowed the HIG to be translated at Transifex, but alas it’s never been fixed.

This pull request is ready for review.
