### PR TITLE
Replace one line conditional with recommended style

### DIFF
--- a/docs/code/reference.md
+++ b/docs/code/reference.md
@@ -32,7 +32,10 @@ White space comes before opening parentheses:
 
 
     public string get_text () {}
-    if (a == 5) return 4;
+    if (a == 5) {
+        return 4;
+    }
+
     for (i = 0; i < maximum; i++) {}
     my_function_name ();
     Object my_instance = new Object ();


### PR DESCRIPTION
We probably shouldn't include a one line conditional in our code style reference if a few lines later we say:
> always use braces even if there's only one line of code

### Changes Summary
- Replace one line conditional with recommended style in code style reference.

This pull request is ready for review.
