### PR TITLE
Updated image links in learning-the-basics in docs.

### DIFF
--- a/docs/learning-the-basics.md
+++ b/docs/learning-the-basics.md
@@ -8,7 +8,7 @@ The elementary OS desktop is very simple and easy to learn. It consists of two e
 ### The Panel {#the-panel}
 At the top of the screen you can see the Panel. On the left is the Applications Menu, in the center are the time and date, and on the right are the Indicators.
 
-![The Panel](../images/docs/learning-the-basics/panel.png)
+![The Panel](https://elementary.io/images/docs/learning-the-basics/panel.png)
 
 #### Applications Menu {#applications}
 

--- a/docs/learning-the-basics.md
+++ b/docs/learning-the-basics.md
@@ -14,7 +14,7 @@ At the top of the screen you can see the Panel. On the left is the Applications 
 
 On the left side of the panel is the Applications Menu. Selecting **Applications** opens the menu with all of your installed apps. You can view multiple pages of apps using the pagers at the bottom or by scrolling. You can also use the view switcher at the top to switch between a grid view and a category view.
 
-![Applications Menu](../images/docs/learning-the-basics/slingshot.png)
+![Applications Menu](https://elementary.io/images/docs/learning-the-basics/slingshot.png)
 
 You can search for apps by name or by keyword and perform actions associated with them. You can also search for System Settings panes. Some of the actions you can find in search include:
 
@@ -39,7 +39,7 @@ A middle click or three finger tap on an indicator will present you with the fol
 ### The Dock {#the-dock}
 At the bottom of the screen is the Dock. It contains your favorite apps well as any apps that are currently open.
 
-![The Dock](../images/docs/learning-the-basics/dock.png)
+![The Dock](https://elementary.io/images/docs/learning-the-basics/dock.png)
 
 The contents of the dock are easily customizable. To add an app to the dock, drag and drop it from the Applications Menu or right-click an open app's icon and choose **Keep in Dock**. To remove an app from the dock, drag it off and drop it in an empty space on your desktop or right-click the icon and uncheck **Keep in Dock**. To rearrange apps on the dock, simply drag and drop them.
 
@@ -59,7 +59,7 @@ Many apps have a HeaderBar at the top of the app. This area contains common acti
 You can move an app's window around the desktop by dragging anywhere on the HeaderBar, including on buttons.
 
 <div class="img--cutoff-bottom">
-    <img src="../images/docs/learning-the-basics/windows.png" alt="HeaderBar">
+    <img src="https://elementary.io/images/docs/learning-the-basics/windows.png" alt="HeaderBar">
 </div>
 
 #### Window Buttons {#window-buttons}
@@ -122,7 +122,7 @@ For more information related to security patches, read the <a href="https://usn.
 
 elementary OS comes with a handy app called "System Settings" that controls all of your system-wide (or "global") preferences. System Settings gives you the ability to adjust things like keyboard shortcuts, display resolution, your wallpaper, and more.
 
-![](../images/docs/learning-the-basics/switchboard.png)
+![](https://elementary.io/images/docs/learning-the-basics/switchboard.png)
 
 ### Search {#search}
 You can quickly find settings you are looking for by typing keywords in the search bar at the top of the window. The contents of the System Settings window will filter down to match your search.


### PR DESCRIPTION
Images in (elementary/website/blob/master/docs/learning-the-basics.md](https://github.com/elementary/website/blob/master/docs/learning-the-basics.md) are broken. Fixed imaged by updating urls.

This pull request is ready for review.