### PR TITLE
Inspecting crashes intro

### DIFF
--- a/docs/code/os-dev.md
+++ b/docs/code/os-dev.md
@@ -130,3 +130,17 @@ G_MESSAGES_DEBUG=all ./Application
 [More information on message logging](https://developer.gnome.org/glib/stable/glib-Message-Logging.html#g-log).
 
 To view logs from all your applications you can use `journalctl`. [More info](https://www.digitalocean.com/community/tutorials/how-to-use-journalctl-to-view-and-manipulate-systemd-logs).
+
+## Inspecting crashes {#inspecting-crashes}
+
+The [Gnome Debugger (gdb)](https://www.gnu.org/software/gdb/) can do a lot, but we're mostly going to focus on getting useful information when an application crashes.
+1. Open an application in gdb, for example AppCenter by running:
+    ```
+    gdb io.elementary.appcenter
+    ```
+2. Now run this application by typing `run` and pressing enter.
+3. If the application doesn't crash right away try reproducing the crash.
+4. Get more information by typing `backtrace` and pressing enter.
+5. Please share the lines after `(gdb) backtrace`, those should provide useful information.
+
+Another tutorial: [Debugging with GDB](https://betterexplained.com/articles/debugging-with-gdb/)

--- a/docs/code/os-dev.md
+++ b/docs/code/os-dev.md
@@ -133,7 +133,7 @@ To view logs from all your applications you can use `journalctl`. [More info](ht
 
 ## Inspecting crashes {#inspecting-crashes}
 
-The [Gnome Debugger (gdb)](https://www.gnu.org/software/gdb/) can do a lot, but we're mostly going to focus on getting useful information when an application crashes.
+The [GNU Project Debugger (gdb)](https://www.gnu.org/software/gdb/) can do a lot, but we're mostly going to focus on getting useful information when an application crashes.
 1. Open an application in gdb, for example AppCenter by running:
     ```
     gdb io.elementary.appcenter


### PR DESCRIPTION
Fixes: #2149

### Changes Summary
- A ultra short intro into using `gdb` to inspect crashes

This pull request is ready for review.
