### PR TITLE
Patch JS-YAML for moderate and high security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,7 +1948,7 @@
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "requires": {
         "is-directory": "0.3.1",
-        "js-yaml": "3.7.0",
+        "js-yaml": ">=3.13.1",
         "minimist": "1.2.0",
         "object-assign": "4.1.1",
         "os-homedir": "1.0.2",


### PR DESCRIPTION
**WS-2019-0032 [moderate severity]**
Vulnerable versions: < 3.13.0
Patched version: 3.13.0
Versions js-yaml prior to 3.13.0 are vulnerable to Denial of Service. By parsing a carefully-crafted YAML file, the node process stalls and may exhaust system resources leading to a Denial of Service.

**WS-2019-0063 [high severity]**
Vulnerable versions: < 3.13.1
Patched version: 3.13.1
Js-yaml prior to 3.13.1 are vulnerable to Code Injection. The load() function may execute arbitrary code injected through a malicious YAML file.

---

This pull request is ready for review.
