### PR TITLE
Patch Tunnel-Agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1533,7 +1533,7 @@
         "get-proxy": "1.1.0",
         "is-obj": "1.0.1",
         "object-assign": "3.0.0",
-        "tunnel-agent": "0.4.3"
+        "tunnel-agent": ">=0.6.0"
       }
     },
     "center-align": {


### PR DESCRIPTION
**WS-2018-0076 [moderate severity]**
Vulnerable versions: < 0.6.0
Patched version: 0.6.0
Versions of tunnel-agent before 0.6.0 are vulnerable to memory exposure.

This is exploitable if user supplied input is provided to the auth value and is a number.

---

This pull request is ready for review.
