### PR TITLE
Align display on hero section

### DIFF
--- a/_styles/home.css
+++ b/_styles/home.css
@@ -124,11 +124,12 @@ input:focus + .focus-reveal {
 }
 
 .section--hero .section__showcase img:not(.bg) {
-    height: 77%;
+    height: 78%;
     left: 50%;
     position: absolute;
     top: 2%;
     transform: translateX(-50%);
+    border-radius: 4px;
 }
 
 /***********************


### PR DESCRIPTION
Maybe it is just me, but for me it looks like the display of the laptop in the hero section is not perfectly aligned.

### Changes Summary

- align display of laptop
- add subtle border-radius similar to the real OS

**Before**
![elementarty_hero_before](https://user-images.githubusercontent.com/24651767/61182888-fc6f2580-a639-11e9-9385-bad9c6746291.png)


**After**
![elementarty_hero_after](https://user-images.githubusercontent.com/24651767/61182885-f9743500-a639-11e9-9455-ad70476ced34.png)



This pull request is ready for review.
