### PR TITLE
move security section from README to security.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See guidelines for [coding](https://github.com/elementary/website/blob/master/.g
 Security
 ========
 
-For any security related issues, please **do not open a public GitHub issue**. Instead, email them to [webmaster@elementary.io](mailto:webmaster@elementary.io). We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks (also, feel free to contribute a fix for the issue).
+Please see [SECURITY.md](./SECURITY.md) for information about disclosure policy and contact.
 
 License
 =======

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+For any security related issues, please **do not open a public GitHub issue**. Instead, email them to [webmaster@elementary.io](mailto:webmaster@elementary.io). We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks (also, feel free to contribute a fix for the issue).


### PR DESCRIPTION
### Changes Summary

- [x] Copy  [security section](https://github.com/elementary/website#security) in README to it's own file. This is part of setting up a [security policy](https://help.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository)

This pull request is ready for review! 😄 

<hr>

👋 Hello! I was looking at your README to get a better idea of the project, and noticed the Security section. I thought it was quite nice to see, but wanted to duplicate it into the `SECURITY.md` file pattern that GitHub is trying to encourage more for projects. This way people can have a single dedicated space (the security tab) for finding out about the projects.

Let me know if you'd like me to edit the README to also just point to this file. Thanks!!