### PR TITLE
Display blog post creation date in UTC

### DIFF
--- a/_scripts/pages/blog.js
+++ b/_scripts/pages/blog.js
@@ -28,7 +28,7 @@ jQuery.then(($) => {
                 postContents += '<span class="name">' + post.author.name + '</span>'
                 postContents += '</div>'
                 var dateJs = new Date(post.pubDate)
-                var dateOptions = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' }
+                var dateOptions = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timezone: 'UTC' }
                 var dateNice = dateJs.toLocaleDateString('en-US', dateOptions)
                 postContents += '<time class="post-date" datetime="' + post.pubDate + '">' + dateNice + '</time>'
                 postContents += '<span class="read-time" title="Estimated read time">'


### PR DESCRIPTION
Conversion errors occur when not specifying to display the date in UTC since the date is created in UTC.

Fixes #2298

### Changes Summary

- Display blog post creation date in UTC

This pull request [ is ] ready for review.
