### PR TITLE
Deactive purchase button for 3 seconds after click

### DIFF
--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -105,6 +105,15 @@ Promise.all([config, jQuery, Payment, modal]).then(([config, $, Payment]) => {
             console.log('Payment initiated with selection ' + currentButton)
             var paymentAmount = $('#' + currentButton).val() * 100
             console.log('Starting payment for ' + paymentAmount)
+            
+            // Disables button for 3 seconds after clicking it
+            var download = $(this);
+            download.prop('disabled', true);
+            setTimeout(function(){
+                    download.prop('disabled', false);
+            }, 3000);
+
+            
             // Free download
             if (Number.isNaN(paymentAmount) || paymentAmount < paymentMinimum) {
                 ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Skip)', 'Homepage', paymentAmount)

--- a/_scripts/pages/download.js
+++ b/_scripts/pages/download.js
@@ -105,15 +105,14 @@ Promise.all([config, jQuery, Payment, modal]).then(([config, $, Payment]) => {
             console.log('Payment initiated with selection ' + currentButton)
             var paymentAmount = $('#' + currentButton).val() * 100
             console.log('Starting payment for ' + paymentAmount)
-            
-            // Disables button for 3 seconds after clicking it
-            var download = $(this);
-            download.prop('disabled', true);
-            setTimeout(function(){
-                    download.prop('disabled', false);
-            }, 3000);
 
-            
+            // Disables button for 3 seconds after clicking it
+            var download = $(this)
+            download.prop('disabled', true)
+            setTimeout(function () {
+                download.prop('disabled', false)
+            }, 3000)
+
             // Free download
             if (Number.isNaN(paymentAmount) || paymentAmount < paymentMinimum) {
                 ga('send', 'event', config.release.title + ' ' + config.release.version + ' Payment (Skip)', 'Homepage', paymentAmount)


### PR DESCRIPTION
Fixes #2311 

### Changes Summary

After clicking on the purchase file a timeout of 3 seconds is set, in which the button cannot be clicked anymore. The website now does not break anymore after double (or n-clicking) on the website. The change is also reflected in the console, since more than one button click within the 3 second frame will only log one message group.

This pull request is ready for review.
