### PR TITLE
Remove unnecessary default_labels

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,16 +3,12 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
-    default_labels:
-      - "dependencies"
     default_reviewers:
       - "lewisgoddard"
       - "btkostner"
   - package_manager: "php:composer"
     directory: "_backend/"
     update_schedule: "weekly"
-    default_labels:
-      - "dependencies"
     default_reviewers:
       - "lewisgoddard"
       - "btkostner"


### PR DESCRIPTION
### Changes Summary
Removes the unnecessary `default_labels` from the Dependabot config, which I added in https://github.com/elementary/website/pull/2260, as by default Dependabot will add labels like so:
<img width="476" alt="Screen Shot 2020-03-29 at 12 17 32" src="https://user-images.githubusercontent.com/1557529/77839398-4a6f8d80-71b7-11ea-910b-b7fac1531661.png">

Also, confirmed this config is valid via [Dependabot's validator](https://dependabot.com/docs/config-file/validator/).
<img width="990" alt="Screen Shot 2020-03-29 at 12 11 19" src="https://user-images.githubusercontent.com/1557529/77839405-59eed680-71b7-11ea-960e-eab5e1de5969.png">

👋 @lewisgoddard, this pull request is ready for review. 🙇‍♂️