### PR TITLE
Fixing inconsistency in brand color palettes

### DIFF
--- a/brand.php
+++ b/brand.php
@@ -70,7 +70,7 @@
             </div>
         </div>
         <div class="color-palette-box">
-            <div class="color-palette-header" style="background: #f37329; color: #ffffff;">
+            <div class="color-palette-header" style="background: #f37329; color: #4D0F00;">
                 <span>Orange</span>
                 <span class="hex" data-l10n-off="1">f37329</span>
             </div>
@@ -122,7 +122,7 @@
             </div>
         </div>
         <div class="color-palette-box">
-            <div class="color-palette-header" style="background-color:#68b723;">
+            <div class="color-palette-header" style="background-color:#68b723; color: #0B2400;">
                 <span>Lime</span>
                 <span class="hex" data-l10n-off="1">68b723</span>
             </div>
@@ -148,7 +148,7 @@
             </div>
         </div>
         <div class="color-palette-box">
-            <div class="color-palette-header" style="background-color:#3689e6;">
+            <div class="color-palette-header" style="background-color:#3689e6; color: #000F33">
                 <span>Blueberry</span>
                 <span class="hex" data-l10n-off="1">3689e6</span>
             </div>


### PR DESCRIPTION
Fixes color inconsitency for color palette headings on the Brand page.

### Screenshot

![palette-text-color](https://user-images.githubusercontent.com/35235201/77851379-2cb32000-71d9-11ea-889c-32e2582bc1f6.png)

### Changes Summary

- Changed 'Orange' heading text color to `#4D0F00` to match the text color used below.
- Changed 'Lime' heading text color to `#0B2400` to match the text color used below.
- Changed 'Blueberry' heading text color to `#000F33` to match the text color used below.

### Other Possibilities

- Leave it be...
- Change the color of the text items below to match the heading text colors

### Status

This pull request is ready for review.
