### PR TITLE
Fix broken link in HIG

### DIFF
--- a/docs/human-interface-guidelines.md
+++ b/docs/human-interface-guidelines.md
@@ -60,7 +60,7 @@ Providing settings can be a way to make sure an app is accessible to a wider set
 
 Design with sane defaults in mind. elementary OS apps put strong emphasis on the out of the box experience. If your app has to be configured before a user is comfortable using it, they may not take the time to configure it at all and simply use another app instead.
 
-<iframe width="420" height="315" src="https://www.youtube.com/embed/G2YNqr-V-xM?rel=0" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/WD-G6ns8oDU" frameborder="0" allowfullscreen></iframe>
 
 ### Ask the Operating System {#ask-the-operating-system}
 


### PR DESCRIPTION
Replaced the broken link to the old Mac ad from a channel that has been taken down with a copy in a relatively reputable channel that is less likely to be removed.

Fixes #2344 

### Changes Summary

- Replaced the embedded video of the old Mac "Out of the Box" ad from a YouTube channel that had been taken down to a copy on a more reputable channel that is less likely to be removed by YouTube.
- Changed the width of the embed because the new one is technically a matted widescreen video instead of the old purely 4:3 version

This pull request [ **is** / is not ] ready for review.
