### PR TITLE
Add shipping notices throughout store, switch to alert style

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -41,4 +41,5 @@ return array(
     'twitter_access_token'    => 'test_atoken',
     'twitter_access_secret'   => 'test_asecret',
 
+    'covid_estimate' => 'Current estimates are 13–16 business days for apparel shipping from the US, 4–7 business days for apparel shipping from the EU, 6–9 business days for mugs shipping from the US, and 2–4 business days for mugs shipping from the EU.',
 );

--- a/_backend/event.php
+++ b/_backend/event.php
@@ -8,7 +8,8 @@
 // Here is an array of events, holding an array with start and end dates.
 $event_expires = array(
     'juno 5.0 release' => [new DateTime('2018-10-11T19:00:00Z'), new DateTime('2018-10-16T19:00:00Z')],
-    'indiegogo appcenter 2/7' => [new DateTime('2020-2-7T18:00:00Z'), new DateTime('2020-3-7T19:00:00Z')]
+    'indiegogo appcenter 2/7' => [new DateTime('2020-2-7T18:00:00Z'), new DateTime('2020-3-7T19:00:00Z')],
+    'covid-19' => [new DateTime('2020-03-01'), new DateTime('2022-12-31')],
 );
 
 /**

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -687,6 +687,10 @@ a.third:hover {
     color: #fbc02d;
 }
 
+.info {
+    color: #3689e6;
+}
+
 .row.alert {
     border: 2px solid #333;
     border-radius: 6px;
@@ -703,6 +707,11 @@ a.third:hover {
     border-color: #fbc02d;
 }
 
+.row.alert.info {
+    background-color: rgba(140, 213, 255, 0.125);
+    border-color: #8cd5ff;
+}
+
 .column.alert {
     margin: 5px;
     max-width: calc(100% - 70px);
@@ -711,6 +720,10 @@ a.third:hover {
 
 .row.alert > .column.alert {
     color: rgba(0, 0, 0, 0.8);
+}
+
+.row.alert.info > .column.alert {
+    color: #002e99;
 }
 
 .column.alert h3 {

--- a/_styles/store.css
+++ b/_styles/store.css
@@ -57,7 +57,7 @@
 
 .modal--product p {
     font-size: 14px;
-    margin: 0;
+    margin: 1em 0;
     text-align: left;
 }
 

--- a/store/cart.php
+++ b/store/cart.php
@@ -26,6 +26,16 @@
     if (count($cart) > 0) {
 ?>
 
+<?php if (event_active('covid-19')) { ?>
+    <div class="row alert info">
+        <div class="column alert">
+            <h3><i class="info fas fa-info-circle"></i> Shipping Delays Due to COVID-19</h3>
+            <p>Orders may experience significant delays. Our fulfillment partner is ensuring the safety of their workers while meeting customer demand.</p>
+            <p><small><?php echo $config['covid_estimate'] ?></small></p>
+        </div>
+    </div>
+<?php } ?>
+
 <form action="<?php echo $page['lang-root'] ?>store/checkout" method="post" class="grid grid--narrow">
     <div class="whole">
         <h1>Cart</h1>

--- a/store/index.php
+++ b/store/index.php
@@ -20,7 +20,7 @@
     );
 
     include $template['header'];
-    // include $template['alert'];
+    include $template['alert'];
 
     $products = \Store\Product\get_products();
 

--- a/store/index.php
+++ b/store/index.php
@@ -20,7 +20,7 @@
     );
 
     include $template['header'];
-    include $template['alert'];
+    // include $template['alert'];
 
     $products = \Store\Product\get_products();
 
@@ -49,7 +49,7 @@
             </div>
             <div class="icon-text">
                 <h3>You are missing API keys</h3>
-                <p>You are viewing a developmental version of the store without configuring api keys. This will lead to false positives and incorrect errors. Please set your keys to testing configuration.</p>
+                <p>You are viewing a development version of the store without configuring API keys. This will lead to false positives and incorrect errors. Please set your keys to testing configuration.</p>
             </div>
         </div>
     </div>
@@ -61,10 +61,19 @@
 <section class="grid">
     <div class="two-thirds">
         <h2>Support Development. Get Swag. Win Win.</h2>
-        <p>Every purchase goes towards developing elementary OS, its apps, and its services. We're a small <a href="/team">team</a>, mostly volunteer, working constantly to make elementary better. Every little bit of help is one step closer to hiring another full-time developer.</p>
-        <p>Due to COVID-19 some orders may experience delays. Please visit Printful's <a href="https://www.printful.com/covid-19" target="_blank" rel="noopener" title="Covid-19 updates for Printful customers">fullfillment estimate page</a> for more details.</p>
+        <p>Every purchase goes towards developing elementary OS, its apps, and its services. We're a small <a href="/team">team</a>, mostly volunteer, working constantly to make elementary better—your support helps make elementary OS more sustainable.</p>
     </div>
 </section>
+
+<?php if (event_active('covid-19')) { ?>
+    <div class="row alert info">
+        <div class="column alert">
+            <h3><i class="info fas fa-info-circle"></i> Shipping Delays Due to COVID-19</h3>
+            <p>Orders may experience significant delays. Our fulfillment partner is ensuring the safety of their workers while meeting customer demand.</p>
+            <p><small><?php echo $config['covid_estimate'] ?></small></p>
+        </div>
+    </div>
+<?php } ?>
 
 <?php foreach ($categories as $category => $products) { ?>
 
@@ -102,6 +111,10 @@
                 <h2><?php echo $product['name'] ?></h2>
                 <h4 data-l10n-off="1"><strong class="modal__price">$<?php echo number_format($product['price_min'], 2) ?></strong> <span class="modal__shipping" data-l10n-off="1"></span></h4>
                 <p><?php echo $product['description'] ?></p>
+
+                <?php if (event_active('covid-19')) { ?>
+                  <p><strong>Due to COVID-19, fulfillment may be delayed.</strong> <?php echo $config['covid_estimate'] ?></p>
+                <?php } ?>
 
                 <input type="hidden" name="id" value="<?php echo $product['id'] ?>">
                 <input type="hidden" name="variant" value="<?php echo $product['variants'][0]['id'] ?>">
@@ -146,7 +159,12 @@
 <section class="grid">
     <div class="two-thirds">
         <h2>Worldwide Shipping</h2>
-        <p>We now ship all around the world! Place your order and choose from a number of shipping methods to fit your needs. Orders are made on-demand typically within 2–7 days.</p>
+        <p>We ship all around the world! Place your order and choose from a number of shipping methods to fit your needs. Orders are made on-demand typically within 2–7 days.</p>
+
+        <?php if (event_active('covid-19')) { ?>
+          <p><strong>Due to COVID-19, fulfillment may be delayed.</strong> <?php echo $config['covid_estimate'] ?></p>
+        <?php } ?>
+
         <p><small>Crimea, Cuba, Iran, Syria, and North Korea excluded. Shipping methods, prices, and times vary by country. Shipments outside of the USA may incur customs fees depending on the destination country.</small></p>
     </div>
 </section>


### PR DESCRIPTION
Improvement to #2349 to fix #2328. Previous link was intended for merchants, not end-users (but was better than nothing). This follows some of Printful's guidance about messaging and adds an alert to the main store page and the cart, plus a paragraph to the shipping section and below item descriptions.

The description is added to the config so we can update it in one place, and I did it as an event so we can more easily change the dates it's affected and end it. If it makes more sense, we can also just check for the existence of the description instead of using an event since we don't know the end date.

~Requires back-end changes to add the notice to the config and the event.~