### PR TITLE
Fix translation updater.

### DIFF
--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -43,7 +43,6 @@ jobs:
           commit-message: "Automatic update of translations files from source"
           title: "Automatic update of translations files from source"
           branch: "update-translations-from-source"
-          path: _lang
         env:
           GITHUB_TOKEN: ${{ secrets.RABBITBOT_TOKEN }}
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/runner/work/_actions/peter-evans/create-pull-request/v2/dist/cpr/create_pull_request.py", line 116, in <module>
    repo = Repo(path)
  File "/opt/hostedtoolcache/Python/3.8.2/x64/lib/python3.8/site-packages/git/repo/base.py", line 181, in __init__
    raise InvalidGitRepositoryError(epath)
git.exc.InvalidGitRepositoryError: /home/runner/work/website/website/_lang
```

[peter-evans/create-pull-request@v2](https://github.com/marketplace/actions/create-pull-request)
`path` - Relative path under GITHUB_WORKSPACE to the **repository**.

---

This pull request is ready for review.
