### PR TITLE
npm ci

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,14 +16,14 @@ For a simple local development environment running on PHP, you will need:
   * `php-xml`
   * `composer`
 * [Node.js](https://nodejs.org/) and `npm`
-  * packages installed with `npm install`
+  * packages installed with `npm ci`
 
 These can be most easily installed on elementaryOS 5.0 (Ubuntu 18.04) with this script:
 
 ```
 sudo apt install php-cli php-curl php-intl php-json php-sqlite3 php-mbstring php-xml composer &&
 sudo apt install nodejs npm &&
-npm install
+npm ci
 ```
 
 Then inside the project directory, run `npm run build && npm run start`. Next,
@@ -77,7 +77,7 @@ sudo service nginx restart
 Then we need to build the static assets.
 
 ```bash
-npm install && npm run build
+npm ci && npm run build
 ```
 
 Finally, navigate to [mvp.localtest.me](http://mvp.localtest.me)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 before_script:
     - "bash -c 'source ~/.nvm/nvm.sh; nvm install 12'"
-    - "bash -c 'source ~/.nvm/nvm.sh; nvm use 12; npm install'"
+    - "bash -c 'source ~/.nvm/nvm.sh; nvm use 12; npm ci'"
 
 script:
     - "bash -c 'source ~/.nvm/nvm.sh; nvm use 12; sh ./_tests/css.sh'"


### PR DESCRIPTION
### Issue

- `npm install` installs based on `package.json` and updates dependencies in `package-lock.json` to their latest version.
- `npm ci` installs based on `package-lock.json` as long as it does not conflict with `package.json`. If it does conflict, it fails.
- This means Travis CI and any deployment or development builds are not currently reproducible.

### Changes Summary

- Updates `npm install` to `npm ci`. This should stop deployments drifting from master and no longer pulling changes.

### References
- [npm ci | npm Documentation](https://docs.npmjs.com/cli/ci.html)
- [What is the difference between “npm install” and “npm ci”?](https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci)

---

This pull request is ready for review.
