### PR TITLE
OEM and Brand refresh

### DIFF
--- a/brand.php
+++ b/brand.php
@@ -19,7 +19,7 @@
 <div class="row docs">
     <h2>Company and Product Names</h2>
     <p>The word <strong>elementary</strong> is a trademark of elementary, Inc. to refer to the company itself. It is always lower-case, even when beginning sentences. It may also be used along with product names (i.e. “elementary OS”) to refer to a specific product of elementary, Inc.</p>
-    <p>The primary product of elementary, Inc. is <strong>elementary OS</strong>. For clarity, elementary OS should never be shortened to “elementary” or any abbreviation.
+    <p>The primary product of elementary, Inc. is <strong>elementary OS</strong>. For clarity, elementary OS should never be shortened to “elementary” or any abbreviation.</p>
 </div>
 
 <div class="row docs">

--- a/brand.php
+++ b/brand.php
@@ -14,34 +14,41 @@
 <div class="row docs">
     <h1>Brand</h1>
     <p>The elementary brand is unique: technically it belongs to elementary, Inc., the company that guides and supports development of elementary products. However, we have a great community and don’t want to be too overbearing with legal requirements and technicalities. As such, we have written up some guidelines to make it easier to understand when and how the elementary brand should be used.</p>
+</div>
 
-    <h2>Name</h2>
-    <p>The word "elementary" refers to and is a trademark of elementary, Inc. elementary is always lower-case, even when beginning sentences such as this. It is also used along with product names (i.e. "elementary OS") to refer to a specific product of elementary.</p>
+<div class="row docs">
+    <h2>Company and Product Names</h2>
+    <p>The word <strong>elementary</strong> is a trademark of elementary, Inc. to refer to the company itself. It is always lower-case, even when beginning sentences. It may also be used along with product names (i.e. “elementary OS”) to refer to a specific product of elementary, Inc.</p>
+    <p>The primary product of elementary, Inc. is <strong>elementary OS</strong>. For clarity, elementary OS should never be shortened to “elementary” or any abbreviation.
+</div>
 
+<div class="row docs">
     <h2>Brand Marks</h2>
-    <p>elementary owns two marks: the "elementary" logotype and the "e" logomark. Both are considered trademarks and represent elementary—the company—and its products.</p>
+    <p>elementary, Inc. claims two marks: the <strong>“elementary” logotype</strong> and the <strong>“e” logomark</strong>. Both are considered trademarks and represent elementary, Inc.</p>
     <p>Both should be used with the following in mind:</p>
     <ul>
-        <li>Do not stretch, skew, rotate, flip, or otherwise alter the marks.</li>
-        <li>Do not use the marks on an overly-busy background; solid colors work best.</li>
-        <li>The marks should always be monochromatic; typically white if on a dark background, or black if on a light background.</li>
+        <li><p>Do not stretch, skew, rotate, flip, or otherwise alter the marks.</p></li>
+        <li><p>Do not use the marks on an overly-busy background; solid colors work best.</p></li>
+        <li><p>The marks should always be monochromatic; typically white if on a dark background, or black if on a light background.</p></li>
     </ul>
 
     <h3>Logotype</h3>
     <img src="<?php echo $sitewide['root'];?>images/brand/logotype.png" alt="elementary Logotype"/>
-    <p>The logotype is to be used when space allows to refer to elementary the company. It can be used before a product name to refer to a specific product of elementary.</p>
+    <p>The logotype is to be used when space allows to refer to elementary, Inc., or it can be used before a product name to refer to a specific product of elementary, Inc.</p>
     <p>The logotype should always be used under the following guidelines:</p>
     <ul>
-        <li>Do not attempt to recreate the logotype. It is a meticulously-designed brand mark, not simply "elementary" written in a specific font.</li>
-        <li>Do not use the logotype at small sizes; if it is not clear, use the logomark instead.</li>
+        <li><p>Do not attempt to recreate the logotype. It is a meticulously-designed brand mark, not simply “elementary” written in a specific font.</p></li>
+        <li><p>Do not use the logotype at small sizes; if it is not clear, use the logomark instead.</p></li>
     </ul>
 
     <h3>Logomark</h3>
     <img src="<?php echo $sitewide['root'];?>images/brand/logomark.png" alt="elementary Logomark"/>
-    <p>The "e" logomark is to be used to refer to elementary the company when space is constrained or a square ratio is required.</p>
+    <p>The “e” logomark is to be used to refer to elementary, Inc. when space is constrained or a square ratio is required.</p>
+</div>
 
+<div class="row docs">
     <h2>Color</h2>
-    <p>elementary employs the use of color combined with our name and marks to establish our brand. We use the following palette:</p>
+    <p>We employ the use of color combined with our name and marks to establish our brand. We use the following palette:</p>
     <div class="color-palette-section">
         <div class="color-palette-box">
             <div class="color-palette-header" style="background: #c6262e; color: #ffffff;">
@@ -356,13 +363,17 @@
             </div>
         </div>
     </div>
+</div>
 
+<div class="row docs">
     <h2>Fonts</h2>
     <p>For web and print, we use Raleway for headings and Open Sans for body copy. For code blocks, we use Roboto Mono.</p>
+</div>
 
+<div class="row docs">
     <section id="community">
         <h2>Third Parties &amp; Community</h2>
-        <p>We encourage third party developers creating products for elementary OS to adopt certain elements of the elementary brand to achieve consistency:</p>
+        <p>We invite third-party developers creating products for elementary OS to adopt certain elements of the elementary brand for consistency:</p>
         <ul>
             <li>Color</li>
             <li>Fonts</li>
@@ -370,37 +381,44 @@
         </ul>
         <p>However, to avoid user confusion, we do restrict the usage of the elementary name and marks:</p>
         <ul>
-            <li>You are encouraged to say that your app or service is designed for elementary OS, but please don't use the elementary name or marks as part of the name of your company, application, product, service, or in any logo you create.</li>
-            <li>Only use the elementary name or marks to refer to elementary, Inc. or its products (i.e. elementary OS).</li>
+            <li><p>You are encouraged to say that your app or service is “designed for elementary OS,” but do not use the elementary name or marks as part of the name of your company, application, product, or service—or in any logo you create.</p></li>
+            <li><p>Only use the elementary name or marks to refer to elementary, Inc. or its products (i.e. elementary OS).</p></li>
         </ul>
 
         <h3>Community</h3>
         <p>Community products (sites, fan clubs, etc.) are encouraged to use the elementary Community logo:</p>
         <img src="<?php echo $sitewide['root'];?>images/brand/community-color.png" alt="elementary Community Logo with color"/>
         <img src="<?php echo $sitewide['root'];?>images/brand/community-black.png" alt="elementary Community Logo in black"/>
-        <p>This helps establish the product as part of the overall elementary community while reducing confusion that can arise from using the main logomark.</p>
+        <p>This helps establish the product as part of the overall community while reducing confusion that can arise from using the elementary, Inc. logomark.</p>
     </section>
+</div>
 
+<div class="row docs">
     <section id="hardware">
         <h2>Hardware Distributors</h2>
-        <p>We want to ensure that as long as our software carries the elementary branding, the experience will be consistent whether it was downloaded from our website or pre-installed on a hardware product.</p>
-        <p>The software components of elementary OS may be modified and redistributed according to the terms of the software’s licensing. However, our brand marks may only be redistributed under one or more of the following conditions:</p>
+        <p>As long as our software carries the elementary branding, the experience must be consistent—whether the OS was downloaded from our website or pre-installed on a hardware product.</p>
+        <p>The software components of elementary OS may be modified and redistributed according to the open source terms of the software’s licensing; however, the above branding and trademarks may only be redistributed under one or more of the following conditions:</p>
         <ol>
-            <li>The software remains unchanged, including pre-installed applications, stylesheets and iconography, configuration files, etc., or</li>
-            <li>The modifications are approved in writing by elementary.</li>
+            <li><p>The software remains substantially unchanged; including default apps, stylesheet and iconography, etc., or</p></li>
+            <li><p>Software modifications are approved by elementary, Inc.</p></li>
         </ol>
-        <p>We understand that including drivers, hardware enablement, and distributor branding is important for distributors, so these modifications will almost always be approved by elementary. If in doubt, please email <a href="mailto:brand@elementary.io">brand@elementary.io</a> for clarification or direction.</p>
-        <p>If you’re unable or unwilling to follow these trademark redistribution terms, removing elementary’s trademarks from the OS should be simple and straightforward:</p>
+        <p>Drivers and hardware enablement are of course acceptable. We understand that distributor branding (i.e. default wallpapers) can be important for distributors, so these modifications will typically be approved. If in doubt, email <a href="mailto:brand@elementary.io">brand@elementary.io</a> for clarification or direction.</p>
+        <p>If you’re unable or unwilling to follow the elementary, Inc. trademark redistribution terms, removing our trademarks from the OS is simple and straightforward:</p>
         <ol>
-            <li>Modify the <code>DISTRIB_DESCRIPTION</code> line in the file <code>/etc/lsb-release</code> to exclude our trademarks.</li>
-            <li>Replace the iconography such that the icon <code>distributor-logo</code> present in <code>/usr/share/icons/elementary/places/</code> in each of the provided sizes does not appear in the OS.</li>
-            <li>Remove the packages <code>plymouth-theme-elementary</code> and <code>plymouth-theme-elementary-text</code>.</li>
+            <li><p>Modify the <code>DISTRIB_DESCRIPTION</code> line in the file <code>/etc/lsb-release</code> to exclude our trademarks.</p></li>
+            <li><p>Replace the iconography such that the icon <code>distributor-logo</code> present in <code>/usr/share/icons/elementary/places/</code> in each of the provided sizes does not appear in the OS.</p></li>
+            <li><p>Remove or replace the packages <code>plymouth-theme-elementary</code> and <code>plymouth-theme-elementary-text</code>.</p></li>
         </ol>
+        <p>For more information about OEMs and hardware distributors, see our <a href="<?php echo $page['lang-root'].'oem'; ?>">information for OEMs</a>.</p>
     </section>
+</div>
 
+<div class="row docs">
     <h2>Merchandise</h2>
-    <p>We do not typically allow our branding (including our name or brand marks) to be used on third-party merchandise.</p>
+    <p>We do not authorize our branding (including our name or brand marks) to be used on third-party merchandise without explicit written approval.</p>
+</div>
 
+<div class="row docs">
     <h2>Assets &amp; More Info</h2>
     <a class="button suggested-action" href="https://github.com/elementary/brand"><i class="fab fa-github"></i> Download on GitHub</a>
     <p>For further information regarding the use of the elementary name, branding, and trademarks, please email <a href="mailto:brand@elementary.io">brand@elementary.io</a>.</p>

--- a/oem.php
+++ b/oem.php
@@ -1,7 +1,7 @@
 <?php
     require_once __DIR__.'/_backend/preload.php';
 
-    $page['title'] = 'OEM Resources &sdot; elementary';
+    $page['title'] = 'Information for OEMs &sdot; elementary';
 
     $page['styles'] = array(
         'styles/oem.css'
@@ -13,37 +13,66 @@
 
 <div class="grid">
     <div class="two-thirds">
-        <h1>OEM Resources</h1>
+        <h1>Information for OEMs</h1>
         <h4>Give your customers the best experience with elementary OS.</h4>
     </div>
 </div>
-
-<div class="grid copy">
+<div class="grid">
     <div class="two-thirds">
-        <h2 id="installation">Installation</h2>
+        <h2>Partners &amp; Retailers</h2>
+        <p>We offer two ways to be listed as an OEM of elementary OS in <a href="<?php echo $page['lang-root'].'store/'; ?>">our store</a>, with differing requirements and benefits.</p>
+    </div>
+    <div class="half copy">
+        <h3>Partner</h3>
+        <p>Model-by-model approval with those specific models featured in <a href="<?php echo $page['lang-root'].'store/'; ?>">our store</a>.</p>
+        <p>Requirements:</p>
+        <ul>
+            <li>Official involvement from elementary, Inc.</li>
+            <li>Negotiable per-device royalty</li>
+            <li>Strict software guidelines</li>
+            <li><a href="<?php echo $page['lang-root'].'brand'; ?>">Trademark compliance</a></li>
+        </ul>
+    </div>
+    <div class="half copy">
+        <h3>Retailer</h3>
+        <p>A link to your website or landing page listed in <a href="<?php echo $page['lang-root'].'store/'; ?>">our store</a>.</p>
+        <p>Requirements:</p>
+        <ul>
+            <li>Selling devices with elementary OS</li>
+            <li>Per-device royalty encouraged</li>
+            <li><a href="<?php echo $page['lang-root'].'brand'; ?>">Trademark compliance</a></li>
+        </ul>
+    </div>
+</div>
+<div class="grid">
+    <div class="two-thirds">
+        <h2>Resources</h2>
+    </div>
+    <div class="two-thirds copy">
+        <h3 id="installation">Installation</h3>
         <p>We recommend using the built-in OEM installation procedure provided by the Ubuntu installer. OEMs can install the OS, configure anything necessary, and then prepare the device for shipping to end users.</p>
         <p><a href="https://help.ubuntu.com/community/Ubuntu_OEM_Installer_Overview" target="_blank" rel="noopener" class="read-more">Ubuntu Instructions</a>
         <p><strong>Note:</strong> a new installer is being developed that will simplify the installation process.</p>
         <p><a href="https://github.com/elementary/installer" target="_blank" rel="noopener" class="read-more">New Installer</a>
 
-        <h2 id="system-settings">System Settings</h2>
+        <h3 id="system-settings">System Settings</h3>
         <p>System Settings offers several advantages to OEMs shipping elementary OS. From its pluggable architecture to easily-provided branding, System Settings was designed with OEMs in mind.</p>
 
-        <h3 id="plugs">Plugs</h3>
+        <h4 id="plugs">Plugs</h4>
         <p>System Settings (codenamed <a href="https://github.com/elementary/switchboard" target="_blank" rel="noopener">Switchboard</a>) uses a concept of “Plugs” to provide pluggable settings for various hardware and software concerns. For example, <a href="https://github.com/elementary/switchboard-plug-mouse-touchpad/" target="_blank" rel="noopener">Mouse & Touchpad settings</a> are provided by a plug.</p>
         <img src="images/oem/switchboard.png" alt="Switchboard" />
         <p>OEMs are able to develop and ship custom plugs if there is special or unique hardware in the machine that would require configuration outside of what is available by default in elementary OS; for example, special sensors or input methods that are not present in most hardware and therefor not implemented by default. Of course if this configuration could be relevant to a broader set of users, contributing upstream to the <a href="https://github.com/elementary?q=switchboard-plug" target="_blank" rel="noopener">existing plugs</a> is heavily encouraged.</p>
         <a href="https://valadoc.org/switchboard-2.0/Switchboard.Plug.html" target="_blank" rel="noopener" class="read-more">Documentation</a>
 
-        <h3 id="oem-info">OEM Info in About</h3>
+        <h4 id="oem-info">OEM Info in About</h4>
         <p>The <a href="https://github.com/elementary/switchboard-plug-about/" target="_blank" rel="noopener">About</a> plug displays system information to the user and provides several system-wide actions, such as restoring settings, reporting issues, and getting help. In addition to software information (like the OS version), it also provides a space for hardware information. By default, this is filled in with a generic image and the system’s hostname. However, OEMs can provide custom branded data for this section.</p>
         <img src="images/oem/switchboard-about.png" alt="Switchboard About" />
         <p>By providing an <code>oem.conf</code> file, OEMs can fill in the manufacturer name, product name, model number, and manufacturer URL. An image can also be provided which replaces the generic hardware icon.</p>
         <a href="https://github.com/elementary/switchboard-plug-about/#oem-configuration" target="_blank" rel="noopener" class="read-more">Learn More</a>
 
-        <h2 id="third-party-repos">Third-Party Repositories</h2>
-        <p>It is highly discouraged to ship elementary OS with software repositories other than the defaults in elementary OS plus a single repository provided and controlled by the OEM. Third-party repos effectively give root access and the ability to overwrite any system packages to potentially untrusted third parties. Even if the party is trustworthy, an OEM’s customer’s security and privacy are now at stake if third parties are compromised, reuse their password on multiple services, etc.</p>
-        <p>Further, if a third-party repository ever becomes unmaintained or unpublished, it may prevent normal system upgrades. This could hold back potentially serious security and stability updates from reaching the OEM’s users.</p>
+        <h3 id="third-party-repos">Third-Party Repositories</h3>
+        <p>It is highly discouraged to ship elementary OS with software repositories other than the defaults in elementary OS plus a single repository provided and controlled by the OEM. <strong>Third-party repos effectively give root access and the ability to overwrite any system packages to potentially untrusted third parties.</strong> Even if the party is trustworthy, an OEM’s customer’s security and privacy are now at stake if third parties are compromised, reuse their password on multiple services, etc.</p>
+        <p>Further, if a third-party repository ever becomes unmaintained or unpublished, <strong>it may prevent normal system upgrades.</strong> This could hold back potentially serious security and stability updates from reaching the OEM’s customers.</p>
     </div>
 </div>
 


### PR DESCRIPTION
Fixes #2411 

- Reframes the OEM page as "Information for OEMs"
- Adds Partner/Retailer distinction and information to OEMs page
- Modifies the Brand page for clarity around "elementary" usage
- Cleans up the Brand formatting and section breaks
- Clarifies branding requirements for hardware distributors