### PR TITLE
Get Involved: Shorten store copy

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -86,7 +86,7 @@
         </div>
         <div class="third">
             <i class="fa fa-shopping-cart"></i>
-            <p>Help us financially, plus get some exclusive elementary gear to show your support to friends, family, and coworkers. Every purchase goes towards developing elementary OS, its apps, and its services.</p>
+            <p>Help us financially, plus get some exclusive elementary gear to show your support to friends, family, and coworkers.</p>
             <a class="button flat" href="<?php echo $page['lang-root'].'store/'; ?>" target="_blank" rel="noopener">Visit Store</a>
         </div>
     </div>


### PR DESCRIPTION
Since things got shuffled around, the store section was too wordy. It was kind of repeating itself, anyway, so this removes the redundant part which makes it about the same length as the others. It also lets the buttons line up more nicely.

## Before

![Screenshot_2020-06-11 Get Involved with elementary OS(1)](https://user-images.githubusercontent.com/611168/84431395-76ac7f00-abe8-11ea-898f-383f04475d43.png)


## After

![Screenshot_2020-06-11 Get Involved with elementary OS](https://user-images.githubusercontent.com/611168/84431371-6dbbad80-abe8-11ea-8104-5a969265c85d.png)
