### PR TITLE
Update Translation.php

### DIFF
--- a/_backend/Console/Translation.php
+++ b/_backend/Console/Translation.php
@@ -134,7 +134,7 @@ foreach ($pages as $page) {
         }
 
         if (count($newTranslations) > 0) {
-            $newData = json_encode($newTranslations, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            $newData = json_encode($newTranslations, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
             file_put_contents($languagePath, $newData . PHP_EOL);
         } elseif (file_exists($languagePath)) {
             unlink($languagePath);


### PR DESCRIPTION
We keep getting pull requests like [this](https://github.com/elementary/website/pull/2441/files) that just add some escapes to forward slashes.

These get unescaped when translated because Weblate doesn't escape them.

They get re-escaped when translations generation run because PHP does escape them by default.

This should mean we only see translations updates when string change.

### Changes Summary

- Stops escaping backslashes when generating translations.

This pull request is ready for review.
