### PR TITLE
Fix #2459: Disable Plausible for local development and beta subdomain

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -87,7 +87,7 @@ $l10n->begin_html_translation();
         <script src="scripts/common.js"></script>
         <script src="scripts/main.js" async></script>
         
-        <?php if ( getenv('PHPENV') == 'production' ) { ?>
+        <?php if ( !empty($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] == 'elementary.io' ) { ?>
         <script async defer data-domain="elementary.io" src="https://stats.elementary.io/js/index.js"></script>
         <?php } ?>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script> 

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -86,7 +86,10 @@ $l10n->begin_html_translation();
         <?php if (!isset($scriptless) || $scriptless === false) { ?>
         <script src="scripts/common.js"></script>
         <script src="scripts/main.js" async></script>
+        
+        <?php if ( getenv('PHPENV') == 'production' ) { ?>
         <script async defer data-domain="elementary.io" src="https://stats.elementary.io/js/index.js"></script>
+        <?php } ?>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script> 
 
         <?php


### PR DESCRIPTION
Fixes #2459

### Changes Summary

- Stop loading Plausible unless it's a production location.
- Keep the array snippet to avoid quoting out tracking everywhere.
- You can still check if they work by putting `plausible` in console.

This pull request is ready for review.
