### PR TITLE
Fix #2162: Translation extract scripts do not extract from template files

### DIFF
--- a/_backend/Lib/L10n.php
+++ b/_backend/Lib/L10n.php
@@ -69,7 +69,8 @@ class L10n
             glob($rootDirectory . '/*.{php,md}', GLOB_BRACE),
             glob($rootDirectory . '/docs/*.md'),
             glob($rootDirectory . '/docs/code/*.md'),
-            glob($rootDirectory . '/store/*.php')
+            glob($rootDirectory . '/store/*.php'),
+            glob($rootDirectory . '/_templates/*.php')
         );
 
         $pages = array();


### PR DESCRIPTION
Fixes #2162: Translation extract scripts do not extract from template files

### Changes Summary

- Add `_tempaltes/*.php` to translation set.

This pull request is ready for review.
