### PR TITLE
Fix #2462: Upgrade highlight.js

### DIFF
--- a/_scripts/lib/highlight.js
+++ b/_scripts/lib/highlight.js
@@ -8,7 +8,7 @@
 import Script from 'scriptjs'
 
 export default new Promise((resolve, reject) => {
-    Script('https://cdn.jsdelivr.net/combine/gh/highlightjs/cdn-release@9/build/highlight.min.js,gh/highlightjs/cdn-release@9/build/languages/vala.min.js', () => {
+    Script('https://cdn.jsdelivr.net/combine/gh/highlightjs/cdn-release@10/build/highlight.min.js,gh/highlightjs/cdn-release@10/build/languages/vala.min.js', () => {
         console.log('highlight.js loaded')
         return resolve(window.hljs)
     })


### PR DESCRIPTION
Fixes #2462

### Changes

- Upgrade from version 9 to version 10.

### Testing Needed

Every `pre`/`code` without class `nohighlight` on pages and `/docs/*.md` needs to be checked for [highlight.js v10 breaking changes](https://github.com/highlightjs/highlight.js/blob/master/VERSION_10_BREAKING_CHANGES.md).

Script in [_scripts/pages/docs/main.js](https://github.com/elementary/website/blob/master/_scripts/pages/docs/main.js)

- [x] /docs/human-interface-guidelines.md
- [x] /docs/installation.md
- [x] /docs/learning-the-basics.md
- [x] /docs/translation-guide.md
- [x] /docs/code/os-dev.md
- [x] /docs/code/reference.md

This pull request is ready for review.
