### PR TITLE
Add Dockerfile

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,27 @@
+<Files ~ "\/(.|_)">
+    Deny from all
+</Files>
+
+<Files ~ "^\/node_modules\/.*">
+    Deny from all
+</Files>
+
+<Files "\.(html|css|js|png|jpg|jpeg|gif|ico|svg|eot|woff|ttf|json)$">
+    ExpiresActive On
+    ExpiresDefault "access plus 1 years"
+</Files>
+
+ErrorDocument 403 /403
+ErrorDocument 404 /404
+ErrorDocument 410 /410
+
+RewriteEngine On
+
+RewriteRule ^/([a-z]{2}(?:_[A-Z]{2})?)/(.*)$ /$2?lang=$1
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^(.*)$ $1/index.php [NC,L]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^([^\.]+)$ $1.php [NC,L]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM alpine AS build
+
+RUN apk add --update \
+    autoconf \
+    automake \
+    composer \
+    g++ \
+    gcc \
+    gettext \
+    git \
+    libc6-compat \
+    libpng \
+    libtool \
+    make \
+    musl \
+    nodejs \
+    npm \
+    php7 \
+    php7-curl \
+    php7-json \
+    yasm \
+    zlib \
+    zlib-dev
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY . /app
+
+RUN git submodule init && git submodule update --force --rebase
+RUN npm ci
+RUN cd _backend && composer install
+RUN npm run build
+
+FROM php:apache
+
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev
+
+RUN docker-php-ext-install \
+    curl \
+    json
+
+RUN a2enmod expires rewrite
+
+RUN rm -rf /var/www/html/*
+COPY --from=build /app /var/www/html
+RUN rm -rf \
+    /var/www/html/_images \
+    /var/www/html/_scripts \
+    /var/www/html/_styles \
+    /var/www/html/_tests \
+    /var/www/html/.github \
+    /var/www/html/node_modules


### PR DESCRIPTION
This adds a `Dockerfile` that will build and host the website.

This moves the actual PHP running from `nginx` to `apache` mainly because there is no _official_ php nginx image, and I would rather just use `apache` instead of making our own. Easier to update. Easier to run. etc. etc.

Things to do:
- [ ] Port nginx config to `.htaccess`
- [ ] Setup configuration to load from environment variables
- [ ] Test
- [ ] Deploy GitHub action to publish the image to DockerHub