### PR TITLE
Remove BountySource badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 The New elementary.io
 ================
 
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=10548672)](https://www.bountysource.com/trackers/10548672-elementary-website)
 [![Build Status](https://travis-ci.org/elementary/website.svg?branch=master)](https://travis-ci.org/elementary/website)
 [![Translation status](https://l10n.elementary.io/widgets/website/-/svg-badge.svg)](https://l10n.elementary.io/engage/website/?utm_source=widget)
 


### PR DESCRIPTION
BountySource is already gone from the get involved page.

This pull request is ready for review.
