### PR TITLE
Store: update COVID notices; move devices up top

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -41,5 +41,5 @@ return array(
     'twitter_access_token'    => 'test_atoken',
     'twitter_access_secret'   => 'test_asecret',
 
-    'covid_estimate' => 'Production is on schedule, but delays may still occur with fulfillment and shipping depending on the order, shipping method, and destination.',
+    'covid_estimate' => '<strong>Due to COVID-19, orders may be delayed.</strong> Production is on schedule, but delays may still occur with fulfillment and shipping depending on the order, shipping method, and destination.',
 );

--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -41,5 +41,5 @@ return array(
     'twitter_access_token'    => 'test_atoken',
     'twitter_access_secret'   => 'test_asecret',
 
-    'covid_estimate' => 'Current estimated delays are 2–7 business days for apparel and 2–5 business days for mugs.',
+    'covid_estimate' => 'Production is on schedule, but delays may still occur with fulfillment and shipping depending on the order, shipping method, and destination.',
 );

--- a/store/index.php
+++ b/store/index.php
@@ -68,15 +68,43 @@
     </div>
 </section>
 
-<?php if (event_active('covid-19')) { ?>
-    <div class="row alert info">
-        <div class="column alert">
-            <h3><i class="info fas fa-info-circle"></i> Shipping Delays Due to COVID-19</h3>
-            <p>Orders may experience delays. Our fulfillment partners are ensuring the safety of their workers while meeting customer demand.</p>
-            <p><small><?php echo $config['covid_estimate'] ?></small></p>
+<section class="grid" id="devices">
+    <div class="two-thirds">
+        <h3>Devices</h3>
+        <p>Hardware devices with elementary OS can be purchased from the following retailers. Purchasing from these companies helps support elementary OS.</p>
+    </div>
+
+    <div class="grid">
+        <div class="third">
+            <h4><a class="read-more" href="https://laptopwithlinux.com/?ref=36&utm_source=referral&utm_medium=elementary&utm_campaign=elementary" target="_blank" title="Visit Laptop With Linux">Laptop With Linux</a></h4>
+            <ul>
+                <li>Laptops, mini desktops</li>
+                <li>Based in the Netherlands</li>
+                <li>Free shipping within EU</li>
+            </ul>
+        </div>
+        <div class="third">
+            <h4><a class="read-more" href="https://slimbook.es?utm_source=referral&utm_medium=elementary&utm_campaign=elementary" target="_blank" title="Visit Slimbook">Slimbook</a></h4>
+            <ul>
+                <li>Laptops, desktops, mini desktops, all-in-ones</li>
+                <li>Based in Spain</li>
+                <li>International shipping</li>
+            </ul>
+        </div>
+        <div class="third">
+            <h4><a class="read-more" href="https://starlabs.systems/?rfsn=4227837.e8f025" target="_blank" title="Visit Star Labs">Star Labs</a></h4>
+            <ul>
+                <li>Laptops</li>
+                <li>Based in the United Kingdom</li>
+                <li>International shipping</li>
+            </ul>
         </div>
     </div>
-<?php } ?>
+
+    <div class="two-thirds">
+        <p><small>Hardware and software support for these devices are provided by the retailer.</small></p>
+    </div>
+</section>
 
 <?php foreach ($categories as $category => $products) { ?>
 
@@ -116,7 +144,7 @@
                 <p><?php echo $product['description'] ?></p>
 
                 <?php if (event_active('covid-19')) { ?>
-                  <p><strong>Due to COVID-19, fulfillment may be delayed.</strong> <?php echo $config['covid_estimate'] ?></p>
+                  <p><strong>Due to COVID-19, orders may be delayed.</strong> <?php echo $config['covid_estimate'] ?></p>
                 <?php } ?>
 
                 <input type="hidden" name="id" value="<?php echo $product['id'] ?>">
@@ -159,52 +187,10 @@
 
 <?php } ?>
 
-<section class="grid" id="devices">
-    <div class="two-thirds">
-        <h3>Devices</h3>
-        <p>Hardware devices with elementary OS can be purchased from the following retailers. Purchasing from these companies helps support elementary OS.</p>
-    </div>
-
-    <div class="grid">
-        <div class="third">
-            <h4><a class="read-more" href="https://laptopwithlinux.com/?ref=36&utm_source=referral&utm_medium=elementary&utm_campaign=elementary" target="_blank" title="Visit Laptop With Linux">Laptop With Linux</a></h4>
-            <ul>
-                <li>Laptops, mini desktops</li>
-                <li>Based in the Netherlands</li>
-                <li>Free shipping within EU</li>
-            </ul>
-        </div>
-        <div class="third">
-            <h4><a class="read-more" href="https://slimbook.es?utm_source=referral&utm_medium=elementary&utm_campaign=elementary" target="_blank" title="Visit Slimbook">Slimbook</a></h4>
-            <ul>
-                <li>Laptops, desktops, mini desktops, all-in-ones</li>
-                <li>Based in Spain</li>
-                <li>International shipping</li>
-            </ul>
-        </div>
-        <div class="third">
-            <h4><a class="read-more" href="https://starlabs.systems/?rfsn=4227837.e8f025" target="_blank" title="Visit Star Labs">Star Labs</a></h4>
-            <ul>
-                <li>Laptops</li>
-                <li>Based in the United Kingdom</li>
-                <li>International shipping</li>
-            </ul>
-        </div>
-    </div>
-
-    <div class="two-thirds">
-        <p><small>Hardware and software support for these devices are provided by the retailer.</small></p>
-    </div>
-</section>
-
 <section class="grid">
     <div class="two-thirds">
         <h2>Worldwide Shipping</h2>
-        <p>We ship apparel and accessories all around the world! Orders are made on-demand typically within 2–7 days and will be shipped with the method you choose at checkout.</p>
-
-        <?php if (event_active('covid-19')) { ?>
-          <p><strong>Due to COVID-19, fulfillment may be delayed.</strong> <?php echo $config['covid_estimate'] ?></p>
-        <?php } ?>
+        <p>We ship apparel and accessories all around the world! Orders are made on-demand typically within 2–7 days and will be shipped with the method you choose at checkout. <?php if (event_active('covid-19')) { ?><strong>Due to COVID-19, orders may be delayed.</strong> <?php echo $config['covid_estimate'] ?><?php } ?></p>
 
         <p><small>Crimea, Cuba, Iran, Syria, and North Korea excluded. Shipping methods, prices, and times vary by country. Shipments outside of the USA may incur customs fees depending on the origin and destination countries.</small></p>
     </div>

--- a/store/index.php
+++ b/store/index.php
@@ -144,7 +144,7 @@
                 <p><?php echo $product['description'] ?></p>
 
                 <?php if (event_active('covid-19')) { ?>
-                  <p><strong>Due to COVID-19, orders may be delayed.</strong> <?php echo $config['covid_estimate'] ?></p>
+                  <p><?php echo $config['covid_estimate'] ?></p>
                 <?php } ?>
 
                 <input type="hidden" name="id" value="<?php echo $product['id'] ?>">
@@ -190,7 +190,7 @@
 <section class="grid">
     <div class="two-thirds">
         <h2>Worldwide Shipping</h2>
-        <p>We ship apparel and accessories all around the world! Orders are made on-demand typically within 2–7 days and will be shipped with the method you choose at checkout. <?php if (event_active('covid-19')) { ?><strong>Due to COVID-19, orders may be delayed.</strong> <?php echo $config['covid_estimate'] ?><?php } ?></p>
+        <p>We ship apparel and accessories all around the world! Orders are made on-demand typically within 2–7 days and will be shipped with the method you choose at checkout. <?php if (event_active('covid-19')) { ?><?php echo $config['covid_estimate'] ?><?php } ?></p>
 
         <p><small>Crimea, Cuba, Iran, Syria, and North Korea excluded. Shipping methods, prices, and times vary by country. Shipments outside of the USA may incur customs fees depending on the origin and destination countries.</small></p>
     </div>


### PR DESCRIPTION
I opted to keep the more contextual notices about COVID-related delays there, but made the copy a bit more optimistic than before. For context, Printful says production is back on schedule but I know I've seen continued delays with shipping. So better to note that to customers.

Fixes #2519 