### PR TITLE
Opt out of centered grids

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -564,6 +564,11 @@ footer ul li a:focus {
         vertical-align: top;
         width: calc(66% - 48px);
     }
+
+    .grid *:only-child p,
+    .grid .two-thirds h1 + p {
+        text-align: center;
+    }
 }
 
 a.third {

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -564,15 +564,6 @@ footer ul li a:focus {
         vertical-align: top;
         width: calc(66% - 48px);
     }
-
-    .grid *:only-child p,
-    .grid .two-thirds h1 + p {
-        text-align: center;
-    }
-}
-
-.third h3 {
-    text-align: center;
 }
 
 a.third {
@@ -590,6 +581,13 @@ a.third:hover {
     font-size: 32px;
     text-align: center;
     display: block;
+}
+
+.grid.flex {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    text-align: left;
 }
 
 /********

--- a/index.php
+++ b/index.php
@@ -125,13 +125,13 @@
             </div>
         </section>
         <section id="workflow" class="grey">
-            <div class="grid">
+            <div class="grid flex">
                 <div class="two-thirds">
                     <h1>Get Work Done. Or Play.</h1>
                     <p>Stay productive and focused with Multitasking View, Picture-in-Picture, Do Not Disturb, and more. Or keep work out of sight when watching videos or playing games.</p>
                 </div>
             </div>
-            <div class="grid">
+            <div class="grid flex">
                 <div class="third">
                     <figure class="multitasking">
                         <div class="workspace"></div>
@@ -428,15 +428,15 @@
                 </div>
             </div>
         </section>
-        <section>
-            <div class="grid">
+        <section id="open-source">
+            <div class="grid flex">
                 <div class="two-thirds">
                     <h1>Everything We Do is Open&nbsp;Source</h1>
                     <p>Our platform itself is entirely open source, and it’s built upon a strong foundation of Free &amp; Open Source software (like GNU/Linux). Plus, we actively collaborate within the ecosystem to improve it for everyone.</p>
                     <a class="read-more" href="/open-source">Explore Our Stack</a>
                 </div>
             </div>
-            <div class="grid">
+            <div class="grid flex">
                 <div class="half">
                     <h2>Secure &amp; Privacy-respecting</h2>
                     <p>When source code is available to audit, anyone—a security researcher, a concerned user, or an OEM shipping the OS on their hardware—can verify that the software is secure and not collecting or leaking personal information.</p>
@@ -459,14 +459,17 @@
             </div>
         </section>
         <section id="privacy">
-            <div class="grid">
+            <div class="grid flex">
                 <div class="two-thirds">
-                    <h1>Privacy-respecting. Through and through.</h1>
+                    <h1>
+                        Privacy-respecting.<br />
+                        Through and through.
+                    </h1>
                     <p>Your data always belongs to you, and only you. We don’t make advertising deals or collect sensitive personal data. We’re funded directly by our users paying what they want for elementary OS and apps on AppCenter. And that’s how it should be.</p>
                     <a class="read-more" href="privacy">Our Privacy Policy</a>
                 </div>
             </div>
-            <div class="grid">
+            <div class="grid flex">
                 <div class="third">
                     <h4>
                         <?php include('images/icons/devices/symbolic/audio-input-microphone-symbolic.svg'); ?>

--- a/oem.php
+++ b/oem.php
@@ -11,14 +11,14 @@
     include $template['alert'];
 ?>
 
-<div class="grid">
+<div class="grid flex">
     <div class="two-thirds">
         <h1>Information for OEMs</h1>
-        <h4>Give your customers the best experience with elementary OS.</h4>
+        <h4>Give your customers the best experience with elementary&nbsp;OS.</h4>
     </div>
 </div>
 
-<div class="grid">
+<div class="grid flex">
     <div class="two-thirds">
         <h2>Partners &amp; Retailers</h2>
         <p>We offer two ways to be listed as an OEM of elementary OS in <a href="<?php echo $page['lang-root'].'store/'; ?>">our store</a>, with differing requirements and benefits.</p>
@@ -46,9 +46,10 @@
     </div>
 </div>
 
-<div class="grid">
+<div class="grid flex">
     <div class="two-thirds">
         <h2>Resources</h2>
+        <p>Documentation and tips for integrating elementary OS with your hardware.</p>
     </div>
     <div class="two-thirds copy">
         <h3 id="installation">Installation</h3>
@@ -78,7 +79,7 @@
     </div>
 </div>
 
-<div class="grid">
+<div class="grid flex">
     <div class="third">
         <h3>News &amp; Announcements</h3>
         <p>We share frequent updates on development, major announcements, tips for developers, featured apps, and other new content via our Blog.</p>

--- a/open-source.php
+++ b/open-source.php
@@ -11,7 +11,7 @@
     include $template['alert'];
 ?>
 
-<div class="grid">
+<div class="grid flex">
     <div class="two-thirds">
         <h1>Everything We Do is Open&nbsp;Source</h1>
         <p>The elementary OS platform is itself entirely open source, and it’s built upon a strong foundation of Free &amp; Open Source software. Plus, we actively collaborate within the ecosystem to improve it for everyone.</p>

--- a/press.php
+++ b/press.php
@@ -11,7 +11,7 @@
     include $template['alert'];
 ?>
 
-<div class="grid">
+<div class="grid flex">
     <div class="two-thirds">
         <h1>Press Resources</h1>
         <p>We love working with press—both within the Linux world and the greater tech and culture beats—to share our story and what we are working on.</p>

--- a/press.php
+++ b/press.php
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<div class="grid">
+<div class="grid flex">
     <div class="two-thirds">
         <h2>Join Our Press List</h2>
         <p>Be the first to know about new releases and significant developments. We send early access to press releases and press kits, including high resolution screenshots. This is a <strong>very low volume</strong> list; we send you the biggest news around once a year.</p>
@@ -54,7 +54,7 @@
                     <div style="position: absolute; left: -5000px;" aria-hidden="true">
                         <input type="text" name="b_6815d99e5893b4e213cdb00d2_142e260a91" tabindex="-1" value="">
                     </div>
-                    <div class="clear">
+                    <div class="clear text-center">
                         <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button suggested-action">
                     </div>
                 </div>
@@ -65,33 +65,41 @@
 </div>
 
 <div class="grey">
-    <div class="grid">
+    <div class="grid flex">
         <div class="two-thirds">
             <h2>elementary OS 5.1 Hera</h2>
             <p>Hera is a major update on a solid foundation. Featuring a completely redesigned login and lockscreen greeter, a new onboarding experience, new ways to sideload and install apps, major System Settings updates, improved core apps, and desktop refinements.</p>
-            <a class="button" href="https://blog.elementary.io/introducing-elementary-os-5-1-hera/" target="_blank" rel="noopener" class="read-more">Read Announcement</a>
-            <a class="button" href="https://github.com/elementary/press-kit/archive/5.1-hera.zip" target="_blank" rel="noopener" class="read-more">Download Press Kit</a>
+            <div class="text-center">
+                <a class="button" href="https://blog.elementary.io/introducing-elementary-os-5-1-hera/" target="_blank" rel="noopener" class="read-more">Read Announcement</a>
+                <a class="button" href="https://github.com/elementary/press-kit/archive/5.1-hera.zip" target="_blank" rel="noopener" class="read-more">Download Press Kit</a>
+            </div>
         </div>
     </div>
 </div>
 
-<div class="grid">
+<div class="grid flex">
     <div class="third">
         <h3>News &amp; Announcements</h3>
         <p>We share frequent updates on development, major announcements, tips for developers, featured apps, and other new content via our official blog.</p>
-        <a class="button" href="https://blog.elementary.io/" target="_blank" rel="noopener">Visit Our Blog</a>
+        <div class="text-center">
+            <a class="button" href="https://blog.elementary.io/" target="_blank" rel="noopener">Visit Our Blog</a>
+        </div>
     </div>
 
     <div class="third">
         <h3>Brand Resources</h3>
         <p>View the elementary logos, brand usage guidelines, color palette, and community logo. Plus download the official high-resolution and vector elementary logo assets.</p>
-        <a class="button" href="brand">View Brand Resources</a>
+        <div class="text-center">
+            <a class="button" href="brand">View Brand Resources</a>
+        </div>
     </div>
 
     <div class="third">
         <h3>Get in Touch</h3>
         <p>Talk directly with the team by emailing us at <a href="mailto:press@elementary.io">press@elementary.io</a>. We welcome requests for interviews, podcast appearances, or just general press inquiries.</p>
-        <a class="button" href="mailto:press@elementary.io">Send an Email</a>
+        <div class="text-center">
+            <a class="button" href="mailto:press@elementary.io">Send an Email</a>
+        </div>
     </div>
 </div>
 

--- a/previous.php
+++ b/previous.php
@@ -31,7 +31,7 @@
             </div>
         </div>
     </div>
-    <div class="grid">
+    <div class="grid flex">
         <div class="two-thirds">
             <h1>Thank You for Downloading elementary OS</h1>
             <div class="action-area">

--- a/privacy.php
+++ b/privacy.php
@@ -6,7 +6,7 @@
     include $template['header'];
     include $template['alert'];
 ?>
-            <div class="grid">
+            <div class="grid flex">
                 <div class="two-thirds">
                     <h1>Privacy</h1>
                     <p>Your data always belongs to you, and only you. We don’t make advertising deals or collect sensitive personal data. We’re funded directly by our users paying what they want for elementary OS and apps on AppCenter. And that’s how it should be.</p>

--- a/store/index.php
+++ b/store/index.php
@@ -58,7 +58,7 @@
     }
 ?>
 
-<section class="grid">
+<section class="grid flex">
     <div class="two-thirds">
         <h1>
             Support Development.<br />
@@ -68,7 +68,7 @@
     </div>
 </section>
 
-<section class="grid" id="devices">
+<section class="grid flex" id="devices">
     <div class="two-thirds">
         <h3>Devices</h3>
         <p>Hardware devices with elementary OS can be purchased from the following retailers. Purchasing from these companies helps support elementary OS.</p>
@@ -187,7 +187,7 @@
 
 <?php } ?>
 
-<section class="grid">
+<section class="grid flex">
     <div class="two-thirds">
         <h2>Worldwide Shipping</h2>
         <p>We ship apparel and accessories all around the world! Orders are made on-demand typically within 2–7 days and will be shipped with the method you choose at checkout. <?php if (event_active('covid-19')) { ?><?php echo $config['covid_estimate'] ?><?php } ?></p>

--- a/support.php
+++ b/support.php
@@ -12,7 +12,7 @@ include $template['header'];
 include $template['alert'];
 ?>
 
-<section class="grid flex">
+<section class="grid">
     <div class="two-thirds">
         <h1>Get Support</h1>
         <p>We rely on our <a href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener">community-powered Stack Exchange</a> for support. Search for common questions, ask your own, or help out by answering some. Pick an app below to jump to questions about it specifically.</p>

--- a/support.php
+++ b/support.php
@@ -12,7 +12,7 @@ include $template['header'];
 include $template['alert'];
 ?>
 
-<section class="grid">
+<section class="grid flex">
     <div class="two-thirds">
         <h1>Get Support</h1>
         <p>We rely on our <a href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener">community-powered Stack Exchange</a> for support. Search for common questions, ask your own, or help out by answering some. Pick an app below to jump to questions about it specifically.</p>

--- a/team.php
+++ b/team.php
@@ -29,7 +29,7 @@ include $template['header'];
 include $template['alert'];
 ?>
 
-<section class="grid">
+<section class="grid flex">
     <div class="two-thirds">
         <h1>Meet the Team</h1>
         <p>We believe in the unique combination of top-notch UX and the world-changing power of Open Source.</p>

--- a/thank-you.php
+++ b/thank-you.php
@@ -1,14 +1,14 @@
 <?php
     require_once __DIR__.'/_backend/preload.php';
     $page['title'] = 'Thank You for Downloading elementary OS';
-    $page['theme-color'] = '#3E4E54';   
-    
+    $page['theme-color'] = '#3E4E54';
+
     include $template['header'];
     include $template['alert'];
 ?>
 
 <section class="hero">
-    <div class="grid">
+    <div class="grid flex">
         <div class="two-thirds">
             <h1>Thank You for Downloading elementary OS</h1>
             <p>For help and more info, read the <a href="<?php echo $page['lang-root'];?>/docs/installation#installation">installation guide</a>. If you purchased elementary OS, check your email for a receipt that includes your link to download elementary OS again for free.</p>


### PR DESCRIPTION
So it turns out a lot of our centered text woes is due to the grid using `text-align: center` and then its children being `display: inline-block`. This PR:

- Stops trying to be so clever with centering based on only-children and non-text-related wrapper classes.
- Adds a new `.grid.flex` class that opts out of that in favor of using flexbox to center things. As a result, we get much nicer left-aligned text while still having the contents centered within the grid.

Another option I considered was swapping `.grid` to work this way by default, but that broke pretty much all the things and would end up resulting in rewriting half the stylesheet and DOM at the same time. This lets us opt into the better layout over time.