### PR TITLE
Fix #2484: Don't hardcode the filename of the iso in the docs

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -8,6 +8,7 @@ return array(
     'release_filename' => 'elementaryos-5.1-stable.20200814.iso',
     'release_size'     => '1.49 GB',
     'release_magnet'   => '73e9c0288c0b62c2646b695219b550fd231fede4',
+    'release_sha256'   => '439110ceadadd13683632ddd273095f72ee9b8d22a7569ac84c2fd1c4d920610',
 
     'previous_title'    => 'Juno',
     'previous_version'  => '0.4.1',

--- a/docs/_mdr/index.php
+++ b/docs/_mdr/index.php
@@ -78,6 +78,8 @@ if (
         $Parsedown = new ParsedownExtra();
         $Content = $Parsedown->text($Content);
         $Content = str_replace('⌘', '&#8984;', $Content);
+        $Content = str_replace('{#release_filename}', $config['release_filename'], $Content);
+        $Content = str_replace('{#release_sha256}', $config['release_sha256'], $Content);
         $Content = $l10n->translate_html($Content);
         echo $Content;
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,7 +64,7 @@ You'll need a USB flash drive with at least 2 GB of free space and a program cal
 5. We generate a checksum (or hash sum) for elementary OS images so you can verify your downloaded file. This ensures that you've received the full, complete download and that your install image is not corrupted in any way. Click  ![the checksum icon](images/docs/installation/rufus_checksum_icon.png) {.inline}  next to "SELECT" and verify that the text next to "SHA256" matches the following hash:
 
 ```bash nohighlight
-439110ceadadd13683632ddd273095f72ee9b8d22a7569ac84c2fd1c4d920610
+{#release_sha256}
 ```
 
 6. If the hashes match, click "START" and wait for the process to finish.
@@ -91,20 +91,20 @@ Verifying your download is an important, but optional step. We generate a checks
 Running the following command in your Terminal:
 
 ```bash nohighlight
-shasum -a 256 ~/Downloads/elementaryos-5.1-stable.20200814.iso
+shasum -a 256 ~/Downloads/{#release_filename}
 ```
 
 Should produce the output:
 
 ```bash nohighlight
-439110ceadadd13683632ddd273095f72ee9b8d22a7569ac84c2fd1c4d920610
+{#release_sha256}
 ```
 
 Note: This is assuming that you have downloaded the .iso file to your Downloads folder.
 In case you have downloaded it elsewhere, please specify the correct path to the downloaded file, as shown below
 
 ```bash nohighlight
-shasum -a 256 <Path to the Downloaded Folder>/elementaryos-5.1-stable.20200814.iso
+shasum -a 256 <Path to the Downloaded Folder>/{#release_filename}
 ```
 
 ## Creating an Install Drive {#creating-an-installation-medium .clear-float}
@@ -138,7 +138,7 @@ In order to start the installation process, you must boot your computer from the
 
 #### Boot Errors
 
-If your Mac doesn't recognize your elementary OS USB Install Drive in the boot menu, you may need to create an elementary OS Install DVD instead. To create one, insert a blank DVD, right click on the ISO file in Finder, and select "Burn elementaryos-5.1-stable.20200814.iso to Disc". When complete, attempt to boot again from the Install DVD.
+If your Mac doesn't recognize your elementary OS USB Install Drive in the boot menu, you may need to create an elementary OS Install DVD instead. To create one, insert a blank DVD, right click on the ISO file in Finder, and select "Burn {#release_filename} to Disc". When complete, attempt to boot again from the Install DVD.
 
 </div>
 
@@ -153,13 +153,13 @@ Verifying your download is an important, but optional step. We generate a checks
 Running the following command in your terminal:
 
 ```bash nohighlight
-sha256sum elementaryos-5.1-stable.20200814.iso
+sha256sum {#release_filename}
 ```
 
 should produce the output:
 
 ```bash nohighlight
-439110ceadadd13683632ddd273095f72ee9b8d22a7569ac84c2fd1c4d920610
+{#release_sha256}
 ```
 
 ## Creating an Install Drive {#creating-an-installation-medium .clear-float}


### PR DESCRIPTION
Fixes #2484 (Not Tested)

### Changes Summary

- Add the 256sum to the config.
- Replace docs strings with config variables when rendered.
- Update docs.

This pull request is ready for review.
