### PR TITLE
Store: Add support for partner devices; add Star LabTop Mk IV

### DIFF
--- a/_styles/store.css
+++ b/_styles/store.css
@@ -1,7 +1,7 @@
-/*************************************
-* Copyright 2016 elementary LLC.     *
-* This file is part of elementary.io *
-*************************************/
+/***************************************
+* Copyright 2016–2020 elementary, Inc. *
+* This file is part of elementary.io   *
+***************************************/
 
 .fa-128.fa-shopping-cart {
     color: #e0e0e0;
@@ -9,15 +9,35 @@
     margin: 24px;
 }
 
-/**********************************
-* Hardware partners and retailers *
-**********************************/
+/*********************************
+* Hardware devices and retailers *
+*********************************/
 
-#devices * {
-    text-align: center;
+#devices h4,
+#devices p {
+    text-align: left;
 }
 
 #devices h4 {
+    margin-bottom: 0;
+}
+
+#devices .device {
+    padding: 1em;
+}
+
+#devices .button {
+    padding: 8px 16px;
+}
+
+#devices .price {
+    display: block;
+    font-size: smaller;
+    font-weight: 600;
+    text-align: left;
+}
+
+#retailers h4 {
     border-bottom: 3px solid #08c;
     font-size: 1.25em;
     font-weight: 900;
@@ -26,12 +46,16 @@
     text-align: left;
 }
 
-#devices ul {
+#retailers p {
+    text-align: center;
+}
+
+#retailers ul {
     margin: 0;
     padding: 0;
 }
 
-#devices li {
+#retailers li {
     line-height: 1.25;
     list-style: none;
     margin: 0.75em 0;

--- a/store/index.php
+++ b/store/index.php
@@ -69,9 +69,19 @@
 </section>
 
 <section class="grid" id="devices">
+    <div class="third device">
+        <img src="https://cdn.shopify.com/s/files/1/2059/5897/files/IV-US-16x1000.webp" />
+        <h4><strong>Star LabTop Mk IV</strong> by Star Labs</h4>
+        <span class="price">From $791</span>
+        <p>Thin, light, and powerful. Incredible multi-touch glass trackpad. 13.3&Prime; ARC display for vivid color without glare. <a href="https://starlabs.systems/pages/labtop-mk-iv?rfsn=4227837.e8f025" class="read-more">Learn More</a></p>
+        <a href="https://starlabs.systems/products/labtop-mk-iv?rfsn=4227837.e8f025" class="button suggested-action">Buy Now</a>
+    </div>
+</section>
+
+<section class="grid" id="retailers">
     <div class="two-thirds">
-        <h3>Devices</h3>
-        <p>Hardware devices with elementary OS can be purchased from the following retailers. Purchasing from these companies helps support elementary OS.</p>
+        <h3>Retailers</h3>
+        <p>Hardware that comes with elementary OS can also be purchased from the following retailers.</p>
     </div>
 
     <div class="grid">
@@ -189,7 +199,7 @@
 
 <section class="grid">
     <div class="two-thirds">
-        <h2>Worldwide Shipping</h2>
+        <h3>Worldwide Shipping</h3>
         <p>We ship apparel and accessories all around the world! Orders are made on-demand typically within 2–7 days and will be shipped with the method you choose at checkout. <?php if (event_active('covid-19')) { ?><?php echo $config['covid_estimate'] ?><?php } ?></p>
 
         <p><small>Crimea, Cuba, Iran, Syria, and North Korea excluded. Shipping methods, prices, and times vary by country. Shipments outside of the USA may incur customs fees depending on the origin and destination countries.</small></p>


### PR DESCRIPTION
This adds a section up top for partner devices, and adds the Star LabTop Mk IV as the first featured device. Ideally over time this will expand to a small selection of partner devices.

- [ ] Use local image
- [ ] Decide if we like the "Learn More" link where it is

**Do not merge** until I say so, as we have to actually ensure the LapTop Mk IV achieves its partner status first. :smile: 