### PR TITLE
Fix typo "WiFi", "Wi-Fi"

### DIFF
--- a/capnet-assist.php
+++ b/capnet-assist.php
@@ -16,7 +16,7 @@
 		<h1>You're connected!</h1>
 		<p>Your Internet connection appears to be working. You can safely close this window and continue using your device.</p>
 		<h2>Why is this window appearing?</h2>
-		<p>elementary OS automatically checks your Internet connection when you connect to a new WiFi network. If it detects there is not an Internet connection (i.e. if you are connecting to a captive portal at a coffee shop or other public location), this window will appear and display the login page.</p>
+		<p>elementary OS automatically checks your Internet connection when you connect to a new Wi-Fi network. If it detects there is not an Internet connection (i.e. if you are connecting to a captive portal at a coffee shop or other public location), this window will appear and display the login page.</p>
 		<p>Some networks can appear to be a captive portal at first, triggering this window, then actually end up connecting. In those cases, you'll see this message and can safely close the window.</p>
 </div>
 


### PR DESCRIPTION
https://l10n.elementary.io/translate/website/capnet-assist/en_CA/?checksum=c3a969142b4c52a3

### Changes Summary

"WiFi" → "Wi-Fi" as per https://en.wikipedia.org/wiki/Wi-Fi

This pull request is ready for review.
