### PR TITLE
Add JS alert that is removed with JS

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -671,7 +671,9 @@ a.third:hover {
 
 #js-alert {
     border-bottom: 1px solid;
+    border-top: 1px solid;
     font-size: 0.8;
+    margin-bottom: 1em;
     order: -1;
     padding: 0 1em;
 }

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -671,7 +671,7 @@ a.third:hover {
 
 #js-alert {
     border-bottom: 1px solid;
-    font-size: 0.85;
+    font-size: 0.8;
     order: -1;
     padding: 0 1em;
 }

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -1,7 +1,7 @@
-/*************************************
-* Copyright 2016 elementary LLC.     *
-* This file is part of elementary.io *
-*************************************/
+/***************************************
+* Copyright 2016–2021 elementary, Inc. *
+* This file is part of elementary.io   *
+***************************************/
 
 @import url('/fonts/inter.css');
 
@@ -669,6 +669,13 @@ a.third:hover {
 * Alerts *
 *********/
 
+#js-alert {
+    border-bottom: 1px solid;
+    font-size: 0.85;
+    order: -1;
+    padding: 0 1em;
+}
+
 .warning {
     color: #fbc02d;
 }
@@ -688,7 +695,8 @@ a.third:hover {
     margin-top: 20px;
 }
 
-.row.alert.warning {
+.row.alert.warning,
+#js-alert {
     background-color: #fff9c4;
     border-color: #fbc02d;
 }
@@ -704,7 +712,8 @@ a.third:hover {
     padding: 5px;
 }
 
-.row.alert > .column.alert {
+.row.alert > .column.alert,
+#js-alert {
     color: rgba(0, 0, 0, 0.8);
 }
 

--- a/_templates/footer.php
+++ b/_templates/footer.php
@@ -38,10 +38,6 @@
                 <li><a href="<?php echo $sitewide['root'].'open-source'; ?>">Open Source</a></li>
             </ul>
         </footer>
-        <div id="js-alert">
-            <p><strong>JavaScript is required</strong> for parts of this site, like downloading elementary OS and some interactive components.</p>
-        </div>
-        <script>document.getElementById("js-alert").remove ();</script>
         <?php
             include $template['legacy'];
             $l10n->set_domain('layout');

--- a/_templates/footer.php
+++ b/_templates/footer.php
@@ -38,6 +38,10 @@
                 <li><a href="<?php echo $sitewide['root'].'open-source'; ?>">Open Source</a></li>
             </ul>
         </footer>
+        <div id="js-alert" class="alert warning">
+            <p><strong>JavaScript is required</strong> for parts of this site, like downloading elementary OS and some interactive components.</p>
+        </div>
+        <script>document.getElementById("js-alert").remove ();</script>
         <?php
             include $template['legacy'];
             $l10n->set_domain('layout');

--- a/_templates/footer.php
+++ b/_templates/footer.php
@@ -38,7 +38,7 @@
                 <li><a href="<?php echo $sitewide['root'].'open-source'; ?>">Open Source</a></li>
             </ul>
         </footer>
-        <div id="js-alert" class="alert warning">
+        <div id="js-alert">
             <p><strong>JavaScript is required</strong> for parts of this site, like downloading elementary OS and some interactive components.</p>
         </div>
         <script>document.getElementById("js-alert").remove ();</script>

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -134,6 +134,12 @@ $l10n->begin_html_translation();
             </div>
         </nav>
 
+        <noscript>
+            <div id="js-alert">
+                <p><strong>JavaScript is required</strong> for parts of this site, like downloading elementary OS and some interactive components.</p>
+            </div>
+        </noscript>
+
         <?php require __DIR__ . '/event.php'; ?>
 
     <?php if (event_active('indiegogo appcenter 2/7')) { ?>


### PR DESCRIPTION
Fixes #2672 

### Changes Summary

- Adds a JS alert just below the closing `</body>` tag
- Styles it with some simple warning styling
- Immediately removes it with inline JS

This pull request is ready for review.

![Screenshot from 2021-03-18 12-37-36](https://user-images.githubusercontent.com/611168/111679320-cc9cfb80-87e6-11eb-9070-f07f7c625f11.png)

