### PR TITLE
Get Involved: Remove crypto section

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -84,11 +84,6 @@
             <p>Set up a recurring contribution through Liberapay, the open source and non-profit funding platform.</p>
             <a class="button flat" title="Liberapay" href="https://liberapay.com/elementary/" target="_blank" rel="noopener">Contribute with Liberapay</a>
         </div>
-        <div class="third">
-            <i class="fab fa-btc"></i>
-            <p>Contribute via cryptocurrency with Coinbase. We can securely accept Bitcoin, Ethereum, and other cryptocurrencies instantly.</p>
-            <a class="button flat" href="https://commerce.coinbase.com/checkout/d4dbaa95-5a48-42ec-8731-af867e90e4b4">Pay with Crypto</a>
-        </div>
     </div>
 </section>
 


### PR DESCRIPTION
Fixes #2731 by removing the crypto section on the Get Involved page. Leaves those two bottom sections as `third` since they're smaller and center up nicely. We can always revisit the design later but this was the least invasive change.

![Screenshot 2021-06-03 at 12-09-10 Get Involved with elementary OS](https://user-images.githubusercontent.com/611168/120692250-c40ea580-c464-11eb-9fe8-522729caaa8c.png)
