### PR TITLE
change url of elementar's store at translation doc

### DIFF
--- a/docs/translation-guide.md
+++ b/docs/translation-guide.md
@@ -36,4 +36,4 @@ We won't support translation of the following pages:
 * <a href="https://docs.elementary.io/develop/" data-l10n-off="1">Developer Documentation</a>
 * <a href="https://elementary.io/docs/human-interface-guidelines" data-l10n-off="1">Human Interface Guidlines</a>
 * <a href="https://elementary.io/docs/code/reference" data-l10n-off="1">Reference</a>
-* <a href="https://elementary.io/store/" data-l10n-off="1">Store</a>
+* <a href="https://store.elementary.io/" data-l10n-off="1">Store</a>


### PR DESCRIPTION
Fixes #
update link to store at [translation guide](https://github.com/elementary/website/blob/master/docs/translation-guide.md)

### Changes Summary
before: https://elementary.io/store/

after: https://store.elementary.io/
- 
- 
- 

This pull request is ready for review.
