### PR TITLE
Redirect legacy store links to new store

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -67,6 +67,9 @@ server {
   location /download {
     return 301 /;
   }
+  location /store {
+    return 301 http://store.elementary.io/;      
+  }
   location /payment {
     return 301 /;
   }


### PR DESCRIPTION
Fixes #2719

### Changes Summary
- Adds a new redirect for https://elementary.io/store/ to https://store.elementary.io

This pull request is ready for review.
