### PR TITLE
Fix documentation getting started redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,9 @@ server {
   location /docs {
     try_files $uri /docs/_mdr/index.php?$args;
   }
-
+  location = /docs/getting-started {
+    return 301 https://docs.elementary.io/develop;
+  }
   location ~ /\. {
     deny all;
   }


### PR DESCRIPTION
Fixes #2348; based on suggestion from @lewisgoddard 

### Changes Summary
- Adds a redirect from https://elementary.io/docs/getting-started to https://docs.elementary.io/develop

This pull request is ready for review.
