### PR TITLE
Index: Fix workflow screenshots on HiDPI

### DIFF
--- a/index.php
+++ b/index.php
@@ -137,7 +137,7 @@
         <div class="third">
           <figure class="pip">
             <div class="workspace">
-              <img class="window" src="images/screenshots/videos.png" srcset="images/screenshots/videos@2x.png 2x" alt="Videos screenshot" />
+              <img class="window" src="images/screenshots/videos.png" width="1124" height="555" alt="Videos screenshot" />
             </div>
           </figure>
           <h4>Picture-in-Picture</h4>
@@ -146,7 +146,7 @@
         <div class="third">
           <figure class="dnd">
             <div class="workspace">
-              <img class="window" src="images/screenshots/code.png" srcset="images/screenshots/code@2x.png 2x" alt="Code screenshot" />
+              <img class="window" src="images/screenshots/code.png" width="1174" height="703" alt="Code screenshot" />
               <div class="notification" type="notification">
                 <img src="images/icons/apps/64/internet-mail.svg" />
               </div>


### PR DESCRIPTION
Something I noticed: we were grabbing `@2x` screenshots on HiDPI which were outdated since all screenshots are now HiDPI. I dropped the 2x versions and added the dimensions to ensure aspect ratios and max sizes are correct by default, like we do elsewhere using the same images.