### PR TITLE
fix: add rel=me to mastodon

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -125,7 +125,7 @@ $l10n->begin_html_translation();
                 <ul class="right">
                     <li><a href="https://youtube.com/user/elementaryproject" target="_blank" rel="noopener" data-l10n-off title="Youtube"><i class="fab fa-youtube"></i></a></li>
                     <li><a href="https://www.facebook.com/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Facebook"><i class="fab fa-facebook-f"></i></a></li>
-                    <li><a href="https://mastodon.social/@elementary" target="_blank" rel="noopener" data-l10n-off title="Mastodon"><i class="fab fa-mastodon"></i></a></li>
+                    <li><a href="https://mastodon.social/@elementary" target="_blank" rel="noopener me" data-l10n-off title="Mastodon"><i class="fab fa-mastodon"></i></a></li>
                     <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Reddit"><i class="fab fa-reddit"></i></a></li>
                     <li><a href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener" data-l10n-off title="Stack Exchange"><i class="fab fa-stack-exchange"></i></a></li>
                     <li><a href="https://twitter.com/elementary" target="_blank" rel="noopener" data-l10n-off title="Twitter"><i class="fab fa-twitter"></i></a></li>


### PR DESCRIPTION
Fixes N/A

### Changes Summary

- Adds `rel="me"` to the Mastodon social link.

This pull request is ready for review.

---

Minor pet peeve, but on Mastodon your site isn't verified because it doesn't have `rel="me"` in the HTML.

![image](https://user-images.githubusercontent.com/22801583/132126367-8317415d-ea8e-4cc6-b28f-8cab65288166.png)

> If you put a link in your profile metadata, Mastodon checks if the linked page links back to your Mastodon profile. If so, you get a verification checkmark next to that link, since you are confirmed as the owner.
> 
> Behind the scenes, Mastodon checks for the `rel="me"` attribute on the link back. Likewise, Mastodon puts `rel="me"` on the links within profile metadata.
> — https://docs.joinmastodon.org/user/profile/

After this, it should display it as a verified link. That way users don't have to manually check the website to ensure this is the official Elementary account on Mastodon.

![image](https://user-images.githubusercontent.com/22801583/132126392-ddc28ae3-4a95-4f4b-91a0-cf6b4b136e68.png)
