### PR TITLE
Add focus indicator to blog post titles

### DIFF
--- a/_styles/blog.css
+++ b/_styles/blog.css
@@ -85,6 +85,10 @@
   margin-bottom: 1em;
 }
 
+#whats-new .featured:focus header h4 {
+  text-decoration: underline;
+}
+
 #whats-new .featured header h4 + p {
   line-height: 1.25;
   margin-top: -1em;


### PR DESCRIPTION
Fixes #2849

### Changes Summary

- add an indicator to focused blog post

![focused](https://user-images.githubusercontent.com/1364447/135625773-07b3fe99-8277-4d9e-9c84-cee7b51c14b0.PNG)


This pull request [ is ] ready for review.
