### PR TITLE
Improve styling of 'read more' links

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -203,9 +203,13 @@ img.inline + div.inline {
   opacity: 1;
 }
 
+.read-more {
+  white-space: nowrap;
+}
+
 .read-more::after {
   color: inherit;
-  content: "→";
+  content: "\2192";
   display: inline-block;
   font-style: normal;
   font-weight: inherit;


### PR DESCRIPTION
The "read more" links could be broken by word wrapping depending on the width of the viewport:

![Screenshot from 2021-10-01 20-46-41](https://user-images.githubusercontent.com/478237/135678996-1aa9b32e-4a44-41d8-927b-eb00da7c85e1.png)

This PR adds the `white-space: nowrap` rule to the `.read-more` class so that the links will remain in one piece at all times:

![Screenshot from 2021-10-01 20-48-14](https://user-images.githubusercontent.com/478237/135678998-e632ebf0-c8f0-4a0b-b032-c542bb8a2345.png)

The arrow for the `::after` pseudo-element of those links is also replaced with an Unicode escape sequence, which might hopefully make it less prone to be affected by encoding issues (closes #2851).
