### PR TITLE
Update alt tag for blog post image

### DIFF
--- a/_scripts/pages/blog.js
+++ b/_scripts/pages/blog.js
@@ -13,7 +13,7 @@ jQuery.then(($) => {
             $.each(data.posts, function (n, post) {
                 var postContents = ''
                 postContents += '<a class="featured with-image" href="' + post.url + '">'
-                postContents += '<div class="featured-image" alt="Featured image" style="background-image: url(' + post.image + ');"></div>'
+                postContents += '<div class="featured-image" alt="" style="background-image: url(' + post.image + ');"></div>'
                 postContents += '<header>'
                 postContents += '<h4>' + post.title + '</h4>'
                 postContents += '<p>' + post.description + '</p>'


### PR DESCRIPTION
Fixes #2849

### Changes Summary

This change might still be up for debate but I do agree with the points made here: #2849.
- Since the image provides little value to the blog content and is part of a link it should be `alt=""`

This pull request [ is ] ready for review.
