### PR TITLE
Config: Bump to 6.0.2 ISO

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -5,10 +5,10 @@
 return array(
   'release_title'    => 'Odin',
   'release_version'  => '6',
-  'release_filename' => 'elementaryos-6.0-stable.20210831.iso',
+  'release_filename' => 'elementaryos-6.0-stable.20211005.iso',
   'release_size'     => '2.37 GB',
-  'release_magnet'   => '7b4bce53195f7db8c0ba9b9db04b20228b84b60b',
-  'release_sha256'   => '60bbaca60d8dbf9f5f112ade2ee5924af976ba01ce19e53e871c8deced7ae884',
+  'release_magnet'   => '8de6cffcf38e9f3ee643c33c7db180b5c5b89eb4',
+  'release_sha256'   => '2447bbf98d406788a2b1a75db2062c7548954759e3e032e5c468f2bec172bbb0',
   'release_faq'      => 'https://github.com/elementary/os/wiki/elementary-OS-6-Odin-FAQ',
 
   'previous_title'    => 'Hera',


### PR DESCRIPTION
Filesize is the same, but new filename, magnet, and SHA256. Wait for go-ahead from @lewisgoddard.
