### PR TITLE
Improve accessibility on the showcase widget

### DIFF
--- a/_scripts/pages/showcase.run.js
+++ b/_scripts/pages/showcase.run.js
@@ -32,6 +32,13 @@ jQuery.then(($) => {
             showcase.slideTo('index')
         })
 
+        $('#showcase .showcase-tab .showcase-back').on('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault()
+                showcase.slideTo('index')
+            }
+        })
+
         console.log('Loaded showcase.run.js')
     })
 })

--- a/_scripts/widgets/showcase.js
+++ b/_scripts/widgets/showcase.js
@@ -108,11 +108,14 @@ export default class Showcase {
         for (var i = 0; i < this.slides.length; i++) {
             var n = this.slides[i]
             var $n = $('#' + n, this.container) // current iterated slide
+            var $back = $n.find('.showcase-back')
 
             if (n === rSlide) { // if correct slide
                 $n.addClass('active')
+                if ($back.length) $back.attr('tabindex', 0)
             } else {
                 $n.removeClass('active')
+                if ($back.length) $back.removeAttr('tabindex')
             }
         }
 

--- a/_styles/home.css
+++ b/_styles/home.css
@@ -248,6 +248,10 @@ input:focus + .focus-reveal {
   color: inherit;
 }
 
+#showcase #showcase-grid a:focus {
+  filter: drop-shadow(0 5px 10px rgba(0, 0, 0, 0.5));
+}
+
 /********************
 * showcase programs *
 ********************/
@@ -294,6 +298,10 @@ input:focus + .focus-reveal {
   position: absolute;
   top: 0;
   width: 64px;
+}
+
+#showcase.initialized > div.showcase-tab > .showcase-back:focus {
+  filter: drop-shadow(0 5px 10px rgba(0, 0, 0, 0.5));
 }
 
 #showcase.initialized {


### PR DESCRIPTION
### Changes Summary

- add drop shadow to indicate focus on showcase icons and back button
- add tabindex to the currently active showcase's back button to be selectable
- add keydown handler for the back buttons

#### Examples of focus
![focused_icon](https://user-images.githubusercontent.com/1364447/136486752-eb10f2c3-784b-40a3-b2ef-a47fac99cd7f.png)
![focused_back_button](https://user-images.githubusercontent.com/1364447/136486754-32fa6691-f765-4d0e-a05d-c345787a8bb6.png)


----------- 
Open to suggestions on the focus indicator, maybe an outline instead of drop shadow?

This pull request [ is ] ready for review.
