### PR TITLE
Support: Update with GitHub Discussions links

### DIFF
--- a/_styles/support.css
+++ b/_styles/support.css
@@ -1,10 +1,23 @@
-/*************************************
-* Copyright 2016 elementary LLC.   *
-* This file is part of elementary.io *
-*************************************/
+/***************************************
+* Copyright 2016–2022 elementary, Inc. *
+* This file is part of elementary.io   *
+***************************************/
+
+@media (prefers-color-scheme: dark) {
+  html,
+  body {
+    background-color: #1a1a1a;
+    color: #d4d4d4;
+    fill: #d4d4d4;
+  }
+}
 
 h1 {
   clear: both;
+}
+
+h2 {
+  margin-top: 2em;
 }
 
 a.column {
@@ -46,7 +59,9 @@ a.column h3 {
   margin: 12px 0;
   padding: 12px;
   text-align: left;
-  transition: border-color 150ms ease-in-out;
+  transition:
+    background-color 150ms ease-in-out,
+    border-color 150ms ease-in-out;
   vertical-align: top;
   width: 100%;
   word-wrap: break-word;
@@ -55,6 +70,7 @@ a.column h3 {
 .row.apps .app:hover,
 .row.apps .app:focus,
 .row.apps .app:active {
+  background-color: rgba(0, 0, 0, 0.05);
   border: 1px solid rgba(0, 0, 0, 0.25);
   text-decoration: none;
 }

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -127,7 +127,6 @@ $l10n->begin_html_translation();
                     <li><a href="https://www.facebook.com/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Facebook"><i class="fab fa-facebook-f"></i></a></li>
                     <li><a href="https://mastodon.social/@elementary" target="_blank" rel="noopener me" data-l10n-off title="Mastodon"><i class="fab fa-mastodon"></i></a></li>
                     <li><a href="https://www.reddit.com/r/elementaryos" target="_blank" rel="noopener" data-l10n-off title="Reddit"><i class="fab fa-reddit"></i></a></li>
-                    <li><a href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener" data-l10n-off title="Stack Exchange"><i class="fab fa-stack-exchange"></i></a></li>
                     <li><a href="https://twitter.com/elementary" target="_blank" rel="noopener" data-l10n-off title="Twitter"><i class="fab fa-twitter"></i></a></li>
                     <li><a href="https://community-slack.elementary.io/" target="_blank" rel="noopener" data-l10n-off title="Slack"><i class="fab fa-slack"></i></a></li>
                 </ul>

--- a/support.php
+++ b/support.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/_backend/preload.php';
 $page['title'] = 'Support &sdot; elementary';
 
 $page['styles'] = array(
-    'styles/support.css'
+  'styles/support.css'
 );
 
 include $template['header'];
@@ -13,83 +13,95 @@ include $template['alert'];
 ?>
 
 <section class="grid">
-    <div class="two-thirds">
-        <h1>Get Support</h1>
-        <p>We rely on our <a href="https://elementaryos.stackexchange.com" target="_blank" rel="noopener">community-powered Stack Exchange</a> for support. Search for common questions, ask your own, or help out by answering some. Pick an app below to jump to questions about it specifically.</p>
-    </div>
+  <div class="two-thirds">
+    <h1>Community-Powered Support</h1>
+    <p>Reach out to and participate in our global community. Search for questions, ask your own, or help out by sharing your knowledge. Pick an app or component below to view its specific discussions.</p>
+  </div>
 </section>
 
 <div class="row apps">
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/appcenter" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/system-software-install.svg" alt="AppCenter"/>
-        <span>AppCenter</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/appcenter/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/system-software-install.svg" alt="AppCenter"/>
+    <span>AppCenter</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/calendar" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/office-calendar.svg" alt="Calendar"/>
-        <span>Calendar</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/calendar/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/accessories-calculator.svg" alt="Calendar"/>
+    <span>Calculator</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/camera" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/accessories-camera.svg" alt="Camera"/>
-        <span>Camera</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/calendar/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/office-calendar.svg" alt="Calendar"/>
+    <span>Calendar</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/pantheon-files" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/system-file-manager.svg" alt="Files"/>
-        <span>Files</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/camera/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/accessories-camera.svg" alt="Camera"/>
+    <span>Camera</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/pantheon-mail" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/internet-mail.svg" alt="Mail"/>
-        <span>Mail</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/code/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/thirdparty-icons/apps/64/io.elementary.code.svg" alt="Code"/>
+    <span>Code</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/epiphany" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/web-browser.svg" alt="Epiphany"/>
-        <span>Epiphany</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/files/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/system-file-manager.svg" alt="Files"/>
+    <span>Files</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/music" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/multimedia-audio-player.svg" alt="Music"/>
-        <span>Music</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/mail/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/internet-mail.svg" alt="Mail"/>
+    <span>Mail</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/photos" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/multimedia-photo-manager.svg" alt="Photos"/>
-        <span>Photos</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/music/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/multimedia-audio-player.svg" alt="Music"/>
+    <span>Music</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/code" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/thirdparty-icons/apps/64/io.elementary.code.svg" alt="Code"/>
-        <span>Code</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/photos/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/multimedia-photo-manager.svg" alt="Photos"/>
+    <span>Photos</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/settings" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/preferences-desktop.svg" alt="System Settings"/>
-        <span>System Settings</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/terminal/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/utilities-terminal.svg" alt="Terminal"/>
+    <span>Terminal</span>
+  </a>
 
-    <a class="app" href="https://elementaryos.stackexchange.com/questions/tagged/videos" target="_blank" rel="noopener">
-        <img width="64" height="64" src="images/icons/apps/64/multimedia-video-player.svg" alt="Videos"/>
-        <span>Videos</span>
-    </a>
+  <a class="app" href="https://github.com/elementary/videos/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/multimedia-video-player.svg" alt="Videos"/>
+    <span>Videos</span>
+  </a>
+
+  <a class="app" href="https://github.com/elementary/browser/discussions" target="_blank" rel="noopener">
+    <img width="64" height="64" src="images/icons/apps/64/web-browser.svg" alt="Web"/>
+    <span>Web</span>
+  </a>
 </div>
 
 <div class="row">
-    <h2>Guides</h2>
+  <h2>User Guides &amp; Documentation</h2>
 
-    <a class="column third" href="/docs/installation">
-        <i class="fa fa-download"></i>
-        <h3>Installation</h3>
-        <p>Get help installing elementary OS with our step-by-step guide.</p>
-    </a>
+  <a class="column third" href="/docs/installation">
+    <i class="fa fa-download"></i>
+    <h3>Installation</h3>
+    <p>Get help installing elementary OS with our step-by-step guide.</p>
+  </a>
 
-    <a class="column third" href="/docs/learning-the-basics">
-        <i class="fa fa-book"></i>
-        <h3>Learning the Basics</h3>
-        <p>Walk through the desktop, multi-tasking, keyboard shortcuts and more.</p>
-    </a>
+  <a class="column third" href="/docs/learning-the-basics">
+    <i class="fa fa-book"></i>
+    <h3>Learning the Basics</h3>
+    <p>Walk through the desktop, multi-tasking, keyboard shortcuts and more.</p>
+  </a>
+</div>
+
+<section class="grid">
+  <div class="two-thirds">
+    <h2>Payment &amp; Download Support</h2>
+    <p>If you need help with your purchase of elementary OS—for example, downloading your copy or requesting a refund—please reply to your email receipt and a team member will contact you as soon as possible.</p>
+  </div>
 </div>
 
 <?php


### PR DESCRIPTION
- Fixes #2630
- [x] Removes StackExchange link from nav
- Fixes #2942
- Adds a section explicitly to mention Payment & Download Support
- Renames "Epiphany" to "Web" to match the OS
- Adds "Calculator" since it was missing
- Fixes alphabetization
- Fixes whitespace

![support-gh](https://user-images.githubusercontent.com/611168/150439453-1ee21801-2277-4749-9232-814adb80028f.png)

Other apps (and desktop components) are missing, but I figured we'd get this change to existing links in first before adding more apps/components (especially since that will require pulling in more icons and whatnot).

View without whitespace changes.
