### PR TITLE
Remove btkostner from Dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - lewisgoddard
-  - btkostner
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -17,7 +16,6 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - lewisgoddard
-  - btkostner
 - package-ecosystem: composer
   directory: "/_backend"
   schedule:
@@ -26,4 +24,3 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - lewisgoddard
-  - btkostner


### PR DESCRIPTION
Removing no longer core team member, btkostner, from Dependabot reviewers list to unblock Dependabot from requesting reviews. re: https://github.com/elementary/website/pull/3002#issuecomment-1114724413

Fixes Dependabot requesting reviewers on dependency bump PRs.

This pull request is ready for review.

CC @lewisgoddard 