### PR TITLE
Set description on payment intent

### DIFF
--- a/api/create-checkout-session.php
+++ b/api/create-checkout-session.php
@@ -37,11 +37,13 @@ if (isset($_POST['amount'])) {
     ]);
 
     $stripe->paymentIntents->update(
-        $checkout_session['payment_intent'],
-        ['metadata' => array(
-            'receipt' => 'false',
-            'products' => json_encode(array('ISO-' . $config['release_version']))
-        )]
+        $checkout_session['payment_intent'], [
+            'description' => "$config[release_title] $config[release_version]",
+            'metadata' => array(
+                'receipt' => 'false',
+                'products' => json_encode(array('ISO-' . $config['release_version']))
+            )
+        ]
     );
 
     header("HTTP/1.1 303 See Other");


### PR DESCRIPTION
Adds a description to the payment intent that's visible in the Stripe dashboard.