### PR TITLE
CI: Update translations dependencies

### DIFF
--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -5,6 +5,7 @@ name: Update Translations
 on:
   schedule:
     - cron:  "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 'master'
           submodules: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.22.0
         with:
           php-version: '7.4'
           tools: composer
@@ -45,16 +46,14 @@ jobs:
         run: php _backend/Console/Translation.php
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.RABBITBOT_TOKEN }}
           commit-message: "Automatic update of translations files from source"
           title: "Automatic update of translations files from source"
           branch: "update-translations-from-source"
-        env:
-          GITHUB_TOKEN: ${{ secrets.RABBITBOT_TOKEN }}
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 
       - name: Check outputs
         run: |
-          echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pr_number }}"
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
Translation update action has been broken for a while for various reasons.

Latest failures seem to be because of something an action is doing that GitHub considers a security risk and has disabled. So let's move to the latest versions of these actions and see if we get any further.