### PR TITLE
Bump PHP/Node/Actions versions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.22.0
         with:
-          php-version: 7.4
+          php-version: '8.1'
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 18
 
       - name: Install
         run: npm ci
@@ -47,15 +47,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.22.0
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 18
 
       - name: Install
         run: npm ci
@@ -72,15 +72,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.22.0
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 18
 
       - name: Install
         run: npm ci
@@ -97,15 +97,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.22.0
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 18
 
       - name: Install
         run: npm ci
@@ -121,15 +121,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.22.0
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 18
 
       - name: Install
         run: npm ci

--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -28,8 +28,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@2.22.0
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           tools: composer
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 18
 
       - name: Setup submodules
         run: git submodule init && git submodule update --force --rebase


### PR DESCRIPTION
We're running these Node and PHP versions on the server now, so lets update CI to match