### PR TITLE
Increased navbar icons size and decreased gap

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -324,7 +324,8 @@ nav a:visited {
   display: inline-block;
   fill: inherit;
   margin: 0;
-  padding: 0 12px;
+  padding: 0 10px;
+  font-size: 1.3em;
 }
 
 nav a:focus,


### PR DESCRIPTION
Fixes #3319

### Changes Summary

Changes made in main.css

nav a:visited {
  color: inherit;
  display: inline-block;
  fill: inherit;
  margin: 0;
  padding: 0 10px; /* Decreased the padding to reduce the gap between icons */
  font-size: 1.3em; /* Increase the font size to make icons larger */
}

