### PR TITLE
Remove custom plausible domain

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -97,7 +97,7 @@ $l10n->beginHtmlTranslation();
         <script src="<?php echo $scriptsManifest["scripts/main.js"]?>" async></script>
 
             <?php if (!empty($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] == 'elementary.io') { ?>
-        <script async defer data-domain="elementary.io" src="https://stats.elementary.io/js/index.js"></script>
+        <script async defer data-domain="elementary.io" src="https://plausible.io/js/script.js"></script>
             <?php } ?>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 

--- a/privacy.php
+++ b/privacy.php
@@ -53,7 +53,7 @@ include $template['alert'];
   <h2>elementary.io</h2>
 
   <h3 data-l10n-off>Plausible Analytics</h3>
-  <p>This website uses the open source Plausible Analytics routed through our <code>stats.elementary.io</code> domain to anonymously count visits, downloads, etc. You can see the same data we can see on <a target="_blank" rel="noopener" href="https://plausible.io/elementary.io">the public dashboard</a>. No cookies are used and no personal data—not even an IP address or browser user agent—is stored. For more information, see the <a class="read-more" target="_blank" rel="noopener" href="https://plausible.io/data-policy">Plausible Data Policy</a></p>
+  <p>This website uses the open source Plausible Analytics to anonymously count visits, downloads, etc. You can see the same data we can see on <a target="_blank" rel="noopener" href="https://plausible.io/elementary.io">the public dashboard</a>. No cookies are used and no personal data—not even an IP address or browser user agent—is stored. For more information, see the <a class="read-more" target="_blank" rel="noopener" href="https://plausible.io/data-policy">Plausible Data Policy</a></p>
 
   <h3>Cookies</h3>
   <p><strong>You can choose to disable or selectively turn off any cookies or third-party cookies in your browser settings.</strong></p>


### PR DESCRIPTION
Plausible is currently not working when routed through the `stats.elementary.io` domain. Possibly due to Plausible discontinuing this feature.

We can load directly from Plausible's domain, which is likely to be in a lot of ad/tracking block lists. But this should at least get the functionality working again, and we can look at the new Plausible recommended way of proxying the traffic through an elementary domain afterwards.