### PR TITLE
Re-add /team page as a redirect

### DIFF
--- a/team.php
+++ b/team.php
@@ -1,0 +1,2 @@
+<?php
+header('Location: https://github.com/orgs/elementary/people', true, 302);


### PR DESCRIPTION
### Changes Summary

As suggested in https://github.com/elementary/website/pull/3271#issuecomment-1793764791, this PR re-introduces the [`/team`](https://elementary.io/team) page as a redirect to <https://github.com/orgs/elementary/people>, since there are still pages linking to it, such as the footer of <https://developer.elementary.io/> (and [Cool URLs don't change](https://www.w3.org/Provider/Style/URI) :slightly_smiling_face:).

This pull request is ready for review.

/cc @Claudio-code @RMcNeely 