### PR TITLE
Remove Twitter functionality from quotes on bottom of elementary.io

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -26,9 +26,4 @@ return array(
   'slack_token' => 'asdf-1234567890-7418529630-a7854123692-8412487519',
 
   'sentry_dsn' => false,
-
-  'twitter_consumer_key'    => 'test_ckey',
-  'twitter_consumer_secret' => 'test_csecret',
-  'twitter_access_token'    => 'test_atoken',
-  'twitter_access_secret'   => 'test_asecret',
 );

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -174,35 +174,6 @@ img.inline + div.inline {
   margin-left: 12px;
 }
 
-.inline-tweet {
-  color: inherit;
-}
-
-.inline-tweet:focus,
-.inline-tweet:hover {
-  color: #08c;
-  text-decoration: none;
-}
-
-.inline-tweet::after {
-  color: inherit;
-  content: "\f099";
-  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-  font-family: "Font Awesome\ 5 Brands";
-  font-style: normal;
-  font-weight: inherit;
-  margin-top: 0.2em;
-  opacity: 0;
-  padding-left: 6px;
-  position: absolute;
-  transition: all 0.15s ease-in-out;
-}
-
-.inline-tweet:focus::after,
-.inline-tweet:hover::after {
-  opacity: 1;
-}
-
 .read-more {
   white-space: nowrap;
 }
@@ -386,12 +357,6 @@ nav a[title="StackExchange"]:focus,
 nav a[title="StackExchange"]:hover {
   color: #0d93ff;
   fill: #0d93ff;
-}
-
-nav a[title="Twitter"]:focus,
-nav a[title="Twitter"]:hover {
-  color: #1da1f2;
-  fill: #1da1f2;
 }
 
 nav .logomark {

--- a/index.php
+++ b/index.php
@@ -445,23 +445,23 @@ include $template['alert'];
     <section class="grid" id="the-press">
       <div class="third">
         <a href="https://www.wired.com/2013/11/elementaryos/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/wired.svg'; ?></a>
-        <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;elementary OS is different… a beautiful and powerful operating system.&rdquo; –@WIRED https://elementary.io" target="_blank" rel="noopener">&ldquo;elementary OS is different… a beautiful and powerful operating system.&rdquo;</a>
+        &ldquo;elementary OS is different… a beautiful and powerful operating system.&rdquo;
       </div>
       <div class="third">
         <a href="https://arstechnica.com/gadgets/2018/12/a-tour-of-elementary-os-perhaps-the-linux-worlds-best-hope-for-the-mainstream/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/ars.svg'; ?></a>
-        <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;Gets out of the way and lets you focus on what you need to get done.&rdquo; –@arstechnica https://elementary.io" target="_blank" rel="noopener">&ldquo;Gets out of the way and lets you focus on what you need to get done.&rdquo;</a>
+        &ldquo;Gets out of the way and lets you focus on what you need to get done.&rdquo;
       </div>
       <div class="third">
         <a href="https://www.forbes.com/sites/jasonevangelho/2019/01/29/linux-distro-spotlight-what-i-love-about-elementary-os/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/forbes.svg'; ?></a>
-        <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;I've found myself more productive these past two weeks [using elementary OS] than in the last two months combined.&rdquo; –@forbes https://elementary.io"  target="_blank" rel="noopener">&ldquo;I've found myself more productive these past two weeks [using elementary OS] than in the last two months combined.&rdquo;</a>
+        &ldquo;I've found myself more productive these past two weeks [using elementary OS] than in the last two months combined.&rdquo;
       </div>
       <div class="third">
         <a href="https://web.archive.org/web/20150312112222/http://www.maclife.com/article/columns/future_os_x_may_be_more_elementary_ios_7" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/maclife.svg'; ?></a>
-        <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;A fast, low-maintenance platform that can be installed virtually anywhere.&rdquo; –@MacLife https://elementary.io" target="_blank" rel="noopener">&ldquo;A fast, low-maintenance platform that can be installed virtually anywhere.&rdquo;</a>
+        &ldquo;A fast, low-maintenance platform that can be installed virtually anywhere.&rdquo;
       </div>
       <div class="third">
         <a href="https://lifehacker.com/how-to-move-on-after-windows-xp-without-giving-up-your-1556573928" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/lifehacker.svg'; ?></a>
-        <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;Lightweight and fast… and has a real flair for design and appearances.&rdquo; –@lifehacker https://elementary.io" target="_blank" rel="noopener">&ldquo;Lightweight and fast… and has a real flair for design and appearances.&rdquo;</a>
+        &ldquo;Lightweight and fast… and has a real flair for design and appearances.&rdquo;
       </div>
     </section>
 

--- a/press.php
+++ b/press.php
@@ -23,35 +23,35 @@ include $template['alert'];
   <div>
     <div class="third">
       <a href="https://www.wired.com/2013/11/elementaryos/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/wired.svg'; ?></a>
-      <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;elementary OS is different… a beautiful and powerful operating system.&rdquo; –@WIRED https://elementary.io" target="_blank" rel="noopener">&ldquo;elementary OS is different… a beautiful and powerful operating system.&rdquo;</a>
+      &ldquo;elementary OS is different… a beautiful and powerful operating system.&rdquo;
     </div>
     <div class="third">
       <a href="https://arstechnica.com/gadgets/2018/12/a-tour-of-elementary-os-perhaps-the-linux-worlds-best-hope-for-the-mainstream/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/ars.svg'; ?></a>
-      <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;Gets out of the way and lets you focus on what you need to get done.&rdquo; –@arstechnica https://elementary.io" target="_blank" rel="noopener">&ldquo;Gets out of the way and lets you focus on what you need to get done.&rdquo;</a>
+      &ldquo;Gets out of the way and lets you focus on what you need to get done.&rdquo;
     </div>
   </div>
   <div>
     <div class="third">
       <a href="https://www.forbes.com/sites/jasonevangelho/2019/01/29/linux-distro-spotlight-what-i-love-about-elementary-os/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/forbes.svg'; ?></a>
-      <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;I've found myself more productive these past two weeks [using elementary OS] than in the last two months combined.&rdquo; –@forbes https://elementary.io"  target="_blank" rel="noopener">&ldquo;I've found myself more productive these past two weeks [using elementary OS] than in the last two months combined.&rdquo;</a>
+      &ldquo;I've found myself more productive these past two weeks [using elementary OS] than in the last two months combined.&rdquo;
     </div>
     <div class="third">
       <a href="https://web.archive.org/web/20150312112222/http://www.maclife.com/article/columns/future_os_x_may_be_more_elementary_ios_7" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/maclife.svg'; ?></a>
-      <a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;A fast, low-maintenance platform that can be installed virtually anywhere.&rdquo; –@MacLife https://elementary.io" target="_blank" rel="noopener">&ldquo;A fast, low-maintenance platform that can be installed virtually anywhere.&rdquo;</a>
+      &ldquo;A fast, low-maintenance platform that can be installed virtually anywhere.&rdquo;
     </div>
     <div class="third">
       <a href="https://lifehacker.com/how-to-move-on-after-windows-xp-without-giving-up-your-1556573928" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/lifehacker.svg'; ?></a>
-      <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;Lightweight and fast… and has a real flair for design and appearances.&rdquo; –@lifehacker https://elementary.io" target="_blank" rel="noopener">&ldquo;Lightweight and fast… and has a real flair for design and appearances.&rdquo;</a>
+      &ldquo;Lightweight and fast… and has a real flair for design and appearances.&rdquo;
     </div>
   </div>
   <div>
     <div class="third">
       <a href="https://www.omgubuntu.co.uk/2021/08/elementary-os-6-odin-release" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/omgubuntu.svg'; ?></a>
-      <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;The best way to try elementary [OS] is to install it, and since the install wizard is beautifully simple… that’s fairly easy to do.&rdquo; –@omgubuntu https://elementary.io" target="_blank" rel="noopener">&ldquo;The best way to try elementary [OS] is to install it, and since the install wizard is beautifully simple… that’s fairly easy to do.&rdquo;</a>
+      &ldquo;The best way to try elementary [OS] is to install it, and since the install wizard is beautifully simple… that’s fairly easy to do.&rdquo;
     </div>
     <div class="third">
       <a href="https://www.hostingadvice.com/blog/ethical-operating-systems-from-elementary/" target="_blank" rel="noopener"><?php include __DIR__.'/images/thirdparty-logos/hostingadvice.svg'; ?></a>
-      <a class="inline-tweet" href="https://twitter.com/intent/tweet?original_referer=https://elementary.io&text=&ldquo;Ethical and capable replacement for traditional systems… easy to use and customizable to accommodate various workflows.&rdquo; –@Hosting_Advice https://elementary.io" target="_blank" rel="noopener">&ldquo;Ethical and capable replacement for traditional systems such as Windows and macOS… easy to use and customizable to accommodate various workflows.&rdquo;</a>
+      &ldquo;Ethical and capable replacement for traditional systems such as Windows and macOS… easy to use and customizable to accommodate various workflows.&rdquo;
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixes #3451 

### Changes Summary

- Remove tweet links on press page
- Remove tweet links on home page
- Remove twitter related styling
- Remove twitter keys from config (what were these for? I can't see any references to them)
- Does _not_ remove twitter metadata prompts from [`_templates/header.php`](https://github.com/elementary/website/blob/a53a31ef8a55af1acf954ea8506cfcfa0bf3ad80/_templates/header.php#L59)

This pull request **is** ready for review.
