### PR TITLE
Update docker command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 For a simple local development environment running on PHP, you will need:
 ```
-cd ./dev && docker-compose up -d
+cd ./dev && docker compose up -d
 ```
 just navigate to [localhost:8000](http://localhost:8000/) to view the site.
 


### PR DESCRIPTION
The newer versions of docker dont have the hyphenated command so update the documentation to reflect this.

