### PR TITLE
Fix coding contributions documentation  Docker Web Server instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 For a simple local development environment running on PHP, you will need:
 ```
-cd ./dev && docker compose up -d
+cd dev && docker compose up -d
 ```
 just navigate to [localhost:8000](http://localhost:8000/) to view the site.
 


### PR DESCRIPTION
The coding contributions documentation setup instructions were asking users to change into a non-existing directory.
This PR only changes the documentation.

### Changes Summary

- Fixed the instructions.
- Verified the website loads with the fixed instructions.

This pull request is ready for review.
