### PR TITLE
feat: add /api/sponsors_goal endpoint

### DIFF
--- a/_backend/config.example.php
+++ b/_backend/config.example.php
@@ -21,6 +21,9 @@ return array(
   'stripe_sk' => 'sk_test_hoigesrjgoisrhgilgjrsfjs',
   'stripe_pk' => 'pk_test_hoigesrjgoisrhgilgjrsfjs',
 
+  // Only needs read-only access to public repos
+  'gh_sponsors_token' => 'ghp_1234567890abcdefghij',
+
   'previous_stripe_sk' => 'sk_test_hoigesrjgoisrhgilgjrsfjs',
 
   'slack_token' => 'asdf-1234567890-7418529630-a7854123692-8412487519',

--- a/api/sponsors_goal.php
+++ b/api/sponsors_goal.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once __DIR__ . '/../_backend/bootstrap.php';
+
+// POST to the GitHub GraphQL API to get the sponsorship goal
+$curl = curl_init();
+curl_setopt_array($curl, [
+    CURLOPT_URL => "https://api.github.com/graphql",
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        "Authorization: bearer $config[gh_sponsors_token]",
+        "Content-Type: application/json",
+        "User-Agent: elementary Website"
+    ],
+    CURLOPT_POSTFIELDS => json_encode([
+        "query" => "query { organization(login: \"elementary\") { sponsorsListing { activeGoal { percentComplete, targetValue } } } }"
+    ])
+]);
+
+if (!$response = curl_exec($curl)) {
+    // Return error code if the request fails
+    http_response_code(500);
+    curl_close($curl);
+    die();
+}
+
+curl_close($curl);
+
+$response = json_decode($response, true);
+
+// Check the response has the data we asked for
+if (!isset($response['data']['organization']['sponsorsListing']['activeGoal'])) {
+    // Return error code if the response is invalid
+    http_response_code(500);
+    die();
+}
+
+$goal = $response['data']['organization']['sponsorsListing']['activeGoal'];
+$percent = $goal['percentComplete'];
+$target = $goal['targetValue'];
+
+// Return the goal as a JSON object
+header('Content-Type: application/json');
+echo json_encode([
+    "percent" => $percent,
+    "target" => $target
+]);


### PR DESCRIPTION
Adds an API endpoint to return the current GitHub sponsors goal and the percentage towards it. Example response:

```
{"percent":23,"target":7500}
```

Means we can keep the GitHub token in config on the server and not expose it in a compiled package on the system.