### PR TITLE
Adopt Contributor Covenant as our Code of Conduct

### DIFF
--- a/code-of-conduct.php
+++ b/code-of-conduct.php
@@ -8,27 +8,101 @@
 ?>
             <div class="row">
                 <h1>Code of Conduct</h1>
-                <h2>Community Guidelines</h2>
-                <p>Being involved in the elementary community is an incredible experience; you get to be a part of something big, collaborate with people from around the world, and help people make their computers awesome. However, with that comes a responsibility to follow a predefined set of rules that ensures the best environment for all involved. The following rules are expected to be adhered to any time you’re involved with the community, be it in Slack, on GitHub, on an elementary community site, in person, or anywhere else.</p>
-                <h2>I. Respect</h2>
-                <p>Respecting others is paramount. Be sure to respect people and their opinions, personal background, privacy, and ideas. The elementary community is not a place for disrespectful or hurtful remarks for any reason whatsoever. When giving criticism, approach it constructively and respectfully. Personal attacks are not tolerated. When receiving constructive criticism, take it into consideration and thank the critic for their input, no matter your stance.</p>
-                <h2>II. Content</h2>
-                <p>The elementary community is made up of thousands of users of varying ages, beliefs, and levels of maturity. Because of this, you must be conscious of the content you produce and the remarks you make. No nudity, excess vulgarity, political content, religious content, or inappropriate content should appear in relation to elementary. Ultimately, the elementary moderators have the final say as to what constitutes as inappropriate. If in doubt, consider whether or not it’s something you’d show to a room full of people including children and grandmothers from around the world. If you’re hesitant, don’t do it.</p>
-                <p>Screenshots shared in elementary-moderated communities should not contain themes that imitate another OS, photos or illustrations objectifying an individual, or content that otherwise violates our Code of Conduct.</p>
-                <h2>III. Rumors and Speculation</h2>
-                <p>While the fast-paced and exciting nature of elementary contributes to the want to spread rumors or speculation, avoid it. Discussing future plans is alright, but anytime it’s not a verified fact, disclose it as personal speculation or do not discuss it. Spreading inaccurate information can be detrimental to the community, especially if spread in a negative light.</p>
-                <h2>IV. Helpful Discussion</h2>
-                <p>elementary is powered by individuals coming together in their free time to create something special. It’s important to respect that fact and to always try to contribute to healthy, helpful discussion. If in a meeting, keep on-topic and stay quiet unless you have something helpful that pertains to the immediate discussion. If commenting on the website, keep the discussion related to the content of the Journal entry or Answer topic. If participating in a developer-oriented discussion such as an issue tracker, pull request, mailing list, IRC, or Slack, do not create unnecessary noise by discussing non-development topics; this only derails the discussion and muddies up the logs for developers who may not be present.</p>
-                <p>As a primarily online-based community, it’s important we avoid the potentially negative aspects of the Internet. Do not troll; starting fights or making remarks with the sole purpose of making someone mad is childish and unacceptable. Spam is also unacceptable; this includes posting links to irrelevant sites and repeatedly posting links to the same site. If someone is trolling or spamming, ignore and flag the user.</p>
-                <h2>V. Avoiding Conflict</h2>
-                <p>If you feel someone—be it a new or longtime contributor—is coming off as rude, kindly let the person know. Getting out in front of issues before they compound is critical. Everyone has a role to play in helping communication flow smoothly in our (sometimes challengingly) unique work environment.</p>
-                <p>Similarly, always strive to be professional, accurate, and respectful when interacting with or mentioning other projects, companies, or people. Remember that your words and interactions may be perceived as those of the greater elementary community. While constructive criticism can be helpful, always approach it from a positive direction, and never misrepresent or slander—if you are unsure, err on the side of omitting.</p>
-                <h2>VI. Step Down Considerately</h2>
-                <p>Life priorities, interests, and passions can change. If you’re involved with an elementary-related project but feel you must remove yourself from it, do so in a way that minimizes disruption. When we work together, our work and ideas are no longer just our own; they belong to the elementary community as a whole. Inform other members of the team that you intend to step down, and if possible, help find someone to pick up your work. At the very least, ensure your work can be continued where you left off.</p>
-                <h2>Consequences</h2>
-                <p>If you choose not to follow this code of conduct or otherwise disrupt the community, we reserve the right to do the following: alter or remove any content you’ve posted; deactivate or ban your account on third-party sites; deactivate your account in Slack; or otherwise prevent you from interacting with the community.</p>
-                <hr>
-                <p><em>The elementary Code of Conduct is licensed under the <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">Creative Commons Attribution-Share Alike 3.0</a> license. Certain aspects have been inspired by the <a href="http://www.ubuntu.com/about/about-ubuntu/conduct" target="_blank" rel="noopener">Ubuntu Code of Conduct</a>.</em></p>
+                <h2>Our Pledge</h2>
+                <p>We as members, contributors, and leaders pledge to make participation in our
+                community a harassment-free experience for everyone, regardless of age, body
+                size, visible or invisible disability, ethnicity, sex characteristics, gender
+                identity and expression, level of experience, education, socio-economic status,
+                nationality, personal appearance, race, caste, color, religion, or sexual
+                identity and orientation.</p>
+                <p>We pledge to act and interact in ways that contribute to an open, welcoming,
+                diverse, inclusive, and healthy community.</p>
+                <h2>Our Standards</h2>
+                <p>Examples of behavior that contributes to a positive environment for our
+                community include:</p>
+                <ul>
+                <li>Demonstrating empathy and kindness toward other people</li>
+                <li>Being respectful of differing opinions, viewpoints, and experiences</li>
+                <li>Giving and gracefully accepting constructive feedback</li>
+                <li>Accepting responsibility and apologizing to those affected by our mistakes,
+                and learning from the experience</li>
+                <li>Focusing on what is best not just for us as individuals, but for the overall
+                community</li>
+                </ul>
+                <p>Examples of unacceptable behavior include:</p>
+                <ul>
+                <li>The use of sexualized language or imagery, and sexual attention or advances of
+                any kind</li>
+                <li>Trolling, insulting or derogatory comments, and personal or political attacks</li>
+                <li>Public or private harassment</li>
+                <li>Publishing others&#39; private information, such as a physical or email address,
+                without their explicit permission</li>
+                <li>Other conduct which could reasonably be considered inappropriate in a
+                professional setting</li>
+                </ul>
+                <h2>Enforcement Responsibilities</h2>
+                <p>Community leaders are responsible for clarifying and enforcing our standards of
+                acceptable behavior and will take appropriate and fair corrective action in
+                response to any behavior that they deem inappropriate, threatening, offensive,
+                or harmful.</p>
+                <p>Community leaders have the right and responsibility to remove, edit, or reject
+                comments, commits, code, wiki edits, issues, and other contributions that are
+                not aligned to this Code of Conduct, and will communicate reasons for moderation
+                decisions when appropriate.</p>
+                <h2>Scope</h2>
+                <p>This Code of Conduct applies within all community spaces, and also applies when
+                an individual is officially representing the community in public spaces.
+                Examples of representing our community include using an official email address,
+                posting via an official social media account, or acting as an appointed
+                representative at an online or offline event.</p>
+                <h2>Enforcement</h2>
+                <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be
+                reported to the community leaders responsible for enforcement at
+                contact@elementary.io.
+                All complaints will be reviewed and investigated promptly and fairly.</p>
+                <p>All community leaders are obligated to respect the privacy and security of the
+                reporter of any incident.</p>
+                <h2>Enforcement Guidelines</h2>
+                <p>Community leaders will follow these Community Impact Guidelines in determining
+                the consequences for any action they deem in violation of this Code of Conduct:</p>
+                <h3>1. Correction</h3>
+                <p><strong>Community Impact</strong>: Use of inappropriate language or other behavior deemed
+                unprofessional or unwelcome in the community.</p>
+                <p><strong>Consequence</strong>: A private, written warning from community leaders, providing
+                clarity around the nature of the violation and an explanation of why the
+                behavior was inappropriate. A public apology may be requested.</p>
+                <h3>2. Warning</h3>
+                <p><strong>Community Impact</strong>: A violation through a single incident or series of
+                actions.</p>
+                <p><strong>Consequence</strong>: A warning with consequences for continued behavior. No
+                interaction with the people involved, including unsolicited interaction with
+                those enforcing the Code of Conduct, for a specified period of time. This
+                includes avoiding interactions in community spaces as well as external channels
+                like social media. Violating these terms may lead to a temporary or permanent
+                ban.</p>
+                <h3>3. Temporary Ban</h3>
+                <p><strong>Community Impact</strong>: A serious violation of community standards, including
+                sustained inappropriate behavior.</p>
+                <p><strong>Consequence</strong>: A temporary ban from any sort of interaction or public
+                communication with the community for a specified period of time. No public or
+                private interaction with the people involved, including unsolicited interaction
+                with those enforcing the Code of Conduct, is allowed during this period.
+                Violating these terms may lead to a permanent ban.</p>
+                <h3>4. Permanent Ban</h3>
+                <p><strong>Community Impact</strong>: Demonstrating a pattern of violation of community
+                standards, including sustained inappropriate behavior, harassment of an
+                individual, or aggression toward or disparagement of classes of individuals.</p>
+                <p><strong>Consequence</strong>: A permanent ban from any sort of public interaction within the
+                community.</p>
+                <h2>Attribution</h2>
+                <p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>,
+                version 2.1, available at
+                <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html">https://www.contributor-covenant.org/version/2/1/code_of_conduct.html</a>.</p>
+                <p>Community Impact Guidelines were inspired by
+                <a href="https://github.com/mozilla/diversity">Mozilla&#39;s code of conduct enforcement ladder</a>.</p>
+                <p>For answers to common questions about this code of conduct, see the FAQ at
+                <a href="https://www.contributor-covenant.org/faq">https://www.contributor-covenant.org/faq</a>. Translations are available at
+                <a href="https://www.contributor-covenant.org/translations">https://www.contributor-covenant.org/translations</a>.</p>
             </div>
 <?php
     include $template['footer'];


### PR DESCRIPTION
Replaces our home grown Code of Conduct with the Contributor Covenant

Our old code of conduct was written in a much different time and context and I don't feel it covers the needs of our community any more. It has a lot of gaps with regards to protecting marginalized folks and even includes some arguably sexist/ageist language. It includes some odd tidbits like the screenshots thing that aren't enforced.

The contributor covenant has great inclusive language, is more comprehensive, includes better guidance for community moderators, has clearer terms of enforcement, etc. I think it's just overall a better document written by folks with more experience and is a step up from what we have currently.