### PR TITLE
Dismissable Toasts

### DIFF
--- a/_scripts/pages/main.js
+++ b/_scripts/pages/main.js
@@ -10,8 +10,18 @@ import '~/popover'
 import '~/smooth-scrolling'
 
 jQuery.then(($) => {
+    // Show toasts that haven't been dismissed.
+    $('.toast').each((i, toast) => {
+        const hasBeenDismissed = window.localStorage.getItem('toast-dismissed-' + $(toast).attr('id'))
+        if (!hasBeenDismissed) {
+            $(toast).css('display', 'inline-flex')
+        }
+    })
+
     $('.toast__close').on('click', function (e) {
-        $(this).closest('.toast').hide()
+        const toast = $(this).closest('.toast')
+        $(toast).hide()
+        window.localStorage.setItem('toast-dismissed-' + $(toast).attr('id'), '1')
     })
 
     const menuButton = $('nav .menu-button')

--- a/_styles/main.css
+++ b/_styles/main.css
@@ -645,7 +645,7 @@ a.third:hover {
   border-radius: 6px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   color: #fff;
-  display: inline-flex;
+  display: none;
   flex-wrap: wrap;
   font-size: 14px;
   justify-content: center;

--- a/_templates/event.php
+++ b/_templates/event.php
@@ -3,6 +3,12 @@
 /**
  * _templates/event.php
  * Holds markdown for special event items like a release countdown or campain toast.
+ *
+ * API Notes
+ *
+ * Dismissable toasts
+ * To make a toast dismissable when a user clicks on the .toast__close button,
+ * give each .toast element a unique HTML id.
  */
 
 require_once __DIR__ . '/../_backend/event.php';


### PR DESCRIPTION
Fixes #
This PR makes it so that toasts stay hidden once dismissed by a user. This pull addresses issue https://github.com/elementary/website/issues/2316

### Changes Summary
-  `.toast` elements with a unique HTML id will stay hidden once the `.toast__closed` element is clicked.
- A unique id will be placed in the user's `window.localStorage`, indicating that a toast has been closed.
- Any toasts that have not been closed yet will show automatically on page load.
- Documentation describing this API has been added to the event.php template, so maintainers can make informed use of this feature.

This pull request is ready for review.
