### PR TITLE
Fix docker image builds

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,19 +1,23 @@
+# Current server versions (2026-02-28):
+# - PHP: 8.1.2
+# - Nginx: 1.18
+# - Node: 18.17.1
+# - NPM: 9.6.7
+# - Composer: 2.2.6
 FROM composer:2.5 AS composer
-
+FROM node:18 AS node
 FROM php:8.1-fpm
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y ca-certificates curl gnupg \
-    && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update \
-    && apt-get install -y git libicu-dev nodejs nginx libpng-dev libzip-dev \ 
+    && apt-get install -y ca-certificates curl git gnupg libicu-dev nginx libpng-dev libzip-dev \
     libwebp-dev unzip zip libxml2-dev libjpeg62-turbo-dev zlib1g-dev libfreetype6 libfreetype6-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   elementary-os-website:
     build:

--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
+set -e
 
+# Build the backend
 cd _backend
-composer up
+composer install
 cd ../
+
+# Build the frontend
 npm ci
 npm run build
+
+# Start serving the website
 service nginx start
 php-fpm

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "install:submodule": "git submodule init && git submodule update --force --rebase",
     "install:composer": "cd _backend && composer install",
-    "postinstall": "npm run install:submodule && npm run install:composer",
+    "postinstall": "npm run install:composer",
     "lint": "sh _tests/css.sh && sh _tests/javascript.sh && sh _tests/php.sh",
     "build": "gulp",
     "build:images": "gulp images:rebuild",


### PR DESCRIPTION
Fixes #3947

The dev Docker environment was broken due to several issues that prevented the container from building and serving the site.

### Changes Summary

- Replaced the broken NodeSource `node_18.x` apt repository (EOL since April 2025, no longer distributing packages) with a multi-stage build using the official `node:18` image
- `node`, `npm`, and `npx` are now copied directly from the official image; `npm`/`npx` are created as symlinks into `node_modules/npm/bin/` to preserve correct module resolution
- Consolidated into a single `apt-get` layer, removing the now-unnecessary NodeSource setup steps
- Fixed `composer up` → `composer install` (composer up is not a valid command)
- Added `set -e` so the script exits immediately on any error rather than silently continuing through failures
- Removed `version` from `dev/docker-compose.yml` to get rid of a warning
- Removed `submodule` from normal builds as image cache makes this not required

### Testing
Run `cd ./dev && docker-compose up` and wait for the build to finish, then load [localhost:8000](http://localhost:8000)

This pull request is ready for review.
