### PR TITLE
Stop translation from opening PRs for SVG image compression

### DIFF
--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build
+        run: npx gulp styles scripts
 
       - name: Update
         run: php _backend/Console/Translation.php


### PR DESCRIPTION
Fixes #4053

Since changes were made to how we compress images at build time, the translation workflow has started prompting for just image changes. We can get around this by not rebuilding SVGs during the steps and just do scripts and styles for the manifest file translations depend on.

This pull request is ready for review.
