### PR TITLE
Fix inconsistent theme-color values across pages

### DIFF
--- a/_backend/preload.php
+++ b/_backend/preload.php
@@ -9,7 +9,7 @@ $sitewide['title'] = 'elementary';
 $sitewide['author'] = 'elementary, Inc.';
 $sitewide['description'] = 'Thoughtful, capable, and ethical computing';
 $sitewide['image'] = 'https://elementary.io/images/preview.png';
-$sitewide['theme-color'] = '#3689e6';
+
 
 // Autodetect website root path
 $serverRoot = $_SERVER['DOCUMENT_ROOT'];

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -54,7 +54,10 @@ $l10n->beginHtmlTranslation();
 
         <meta name="description" content="<?php echo !empty($page['description']) ? $page['description'] : $sitewide['description']; ?>">
         <meta name="author"      content="<?php echo !empty($page['author']) ? $page['author'] : $sitewide['author']; ?>">
-        <meta name="theme-color" content="<?php echo !empty($page['theme-color']) ? $page['theme-color'] : $sitewide['theme-color']; ?>">
+
+        <?php if (!empty($page['theme-color'])) { ?>
+        <meta name="theme-color" content="<?php echo $page['theme-color']; ?>">
+        <?php } ?>
 
         <meta name="twitter:card"        content="summary_large_image">
         <meta name="twitter:site"        content="@elementary">

--- a/docs/_mdr/index.php
+++ b/docs/_mdr/index.php
@@ -68,7 +68,7 @@ if (is_readable($Request['Directory']) ||
             'styles/docs.css'
         );
 
-        $page['theme-color'] = '#403757';
+
 
         include $Templates['Header'];
         echo '<div class="row docs">';

--- a/get-involved.php
+++ b/get-involved.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/_backend/preload.php';
 
 $page['title'] = 'Get Involved with elementary OS';
-$page['theme-color'] = '#3E4E54';
+
 
 $page['styles'] = array(
     'https://fonts.googleapis.com/css?family=Marck+Script',

--- a/previous.php
+++ b/previous.php
@@ -4,7 +4,7 @@ require_once __DIR__.'/_backend/preload.php';
 require_once __DIR__.'/_backend/os-payment.php';
 
 $page['title'] = 'Thank You for Downloading elementary OS';
-$page['theme-color'] = '#3E4E54';
+
 
 $page['scripts'] = array(
     'scripts/download.js',

--- a/thank-you.php
+++ b/thank-you.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/_backend/preload.php';
 
 $page['title'] = 'Thank You for Downloading elementary OS';
-$page['theme-color'] = '#3E4E54';
+
 
 include $template['header'];
 include $template['alert'];


### PR DESCRIPTION
## Summary

This PR fixes inconsistent HTML theme-color values across several pages.

### Changes
- Made the theme-color meta tag conditional in `_templates/header.php`
- Removed the global blue default from `_backend/preload.php`
- Removed hardcoded theme-color overrides from:
  - get-involved.php
  - previous.php
  - thank-you.php
  - docs/_mdr/index.php

### Result
Pages now use theme-color values that better match their actual header/background styling instead of inheriting a hardcoded blue value.