### PR TITLE
Get Involved: remove PayPal

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -52,7 +52,6 @@ include $template['alert'];
             <a class="button flat" href="https://www.patreon.com/elementary" target="_blank" rel="noopener">Back on Patreon</a>
         </div>
     </div>
-
   
     <div class="grid">
         <div class="half">
@@ -61,7 +60,6 @@ include $template['alert'];
             <a class="button flat" title="Liberapay" href="https://liberapay.com/elementary/" target="_blank" rel="noopener">Contribute with Liberapay</a>
         </div>
     </div>
-
 </section>
 
 <section id="translations">

--- a/get-involved.php
+++ b/get-involved.php
@@ -56,7 +56,7 @@ include $template['alert'];
     <div class="grid">
         <div class="half">
             <img class="logo" alt="Liberapay" src="images/get-involved/liberapay_logo_black.svg">
-            <p>Set up sponsorships with debit, credit, SEPA, or PayPal through Liberapay: the open source and non-profit funding platform.</p>
+            <p>Set up sponsorships with debit, credit, or SEPA through Liberapay: the open source and non-profit funding platform.</p>
             <a class="button flat" title="Liberapay" href="https://liberapay.com/elementary/" target="_blank" rel="noopener">Contribute with Liberapay</a>
         </div>
     </div>

--- a/get-involved.php
+++ b/get-involved.php
@@ -52,7 +52,7 @@ include $template['alert'];
             <a class="button flat" href="https://www.patreon.com/elementary" target="_blank" rel="noopener">Back on Patreon</a>
         </div>
     </div>
-  
+
     <div class="grid">
         <div class="half">
             <img class="logo" alt="Liberapay" src="images/get-involved/liberapay_logo_black.svg">

--- a/get-involved.php
+++ b/get-involved.php
@@ -39,7 +39,7 @@ include $template['alert'];
             <p class="text-center">With the help of our users and fans, we've been able to grow from a small group of passionate volunteers into a tiny but sustainable company. Every little bit of support helps us improve elementary OS and tackle even more ambitious problems.</p>
         </div>
     </div>
-
+  
     <div class="grid">
         <div class="half">
             <i class="fab fa-github" title="GitHub Sponsors"></i>
@@ -53,23 +53,15 @@ include $template['alert'];
         </div>
     </div>
 
+  
     <div class="grid">
-        <div class="third">
-            <i class="fab fa-paypal"></i>
-            <p>Easily use a debit card, credit card, or PayPal account. You can choose a one-time payment or set up recurring payments.</p>
-            <form action="https://www.paypal.com/cgi-bin/webscr" id="paypalform" method="post" target="_top">
-            <input type="hidden" name="cmd" value="_s-xclick">
-            <input type="hidden" name="hosted_button_id" value="LG382EHQVTDYN">
-            <input type="submit" value="Use PayPal" name="submit" title="PayPal - The safer, easier way to pay online!" class="button flat">
-            <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-            </form>
-        </div>
-        <div class="third">
+        <div class="half">
             <img class="logo" alt="Liberapay" src="images/get-involved/liberapay_logo_black.svg">
-            <p>Set up a recurring contribution through Liberapay, the open source and non-profit funding platform.</p>
+            <p>Set up sponsorships with debit, credit, SEPA, or PayPal through Liberapay: the open source and non-profit funding platform.</p>
             <a class="button flat" title="Liberapay" href="https://liberapay.com/elementary/" target="_blank" rel="noopener">Contribute with Liberapay</a>
         </div>
     </div>
+
 </section>
 
 <section id="translations">

--- a/get-involved.php
+++ b/get-involved.php
@@ -39,7 +39,7 @@ include $template['alert'];
             <p class="text-center">With the help of our users and fans, we've been able to grow from a small group of passionate volunteers into a tiny but sustainable company. Every little bit of support helps us improve elementary OS and tackle even more ambitious problems.</p>
         </div>
     </div>
-  
+
     <div class="grid">
         <div class="half">
             <i class="fab fa-github" title="GitHub Sponsors"></i>


### PR DESCRIPTION
PayPal banned our account for "suspicious activity". Folks can still sponsor us with PayPal through Liberapay so update the copy there